### PR TITLE
[Proposal]: Skeleton API for ACL handling (or at least, the parts pertaining to agent access)

### DIFF
--- a/src/acl.ts
+++ b/src/acl.ts
@@ -30,6 +30,8 @@ export async function unstable_saveFallbackAclFor(
   dataset: LitDataset,
   acl: unstable_Acl
 ): Promise<unstable_Acl | null> {
+  // TODO: Implement this last, and only if we agree with both relevant teams that this is desirable.
+  //       See https://github.com/inrupt/lit-solid-core/pull/89/files/33f9fe5780877cd2764aae6fc62f2da6a4fe5569#r427773611
   throw new Error("To be implemented");
 }
 

--- a/src/acl.ts
+++ b/src/acl.ts
@@ -1,0 +1,100 @@
+import {
+  unstable_Acl,
+  unstable_AclDataset,
+  LitDataset,
+  DatasetInfo,
+  unstable_AclRule,
+  ChangeLog,
+} from "./index";
+
+export async function internal_fetchResourceAcl(
+  dataset: LitDataset
+): Promise<unstable_Acl | null> {
+  throw new Error("To be implemented");
+}
+
+export async function internal_fetchFallbackAcl(
+  dataset: LitDataset
+): Promise<unstable_Acl | null> {
+  throw new Error("To be implemented");
+}
+
+export async function unstable_saveResourceAclFor(
+  dataset: LitDataset,
+  acl: unstable_Acl
+): Promise<unstable_Acl | null> {
+  throw new Error("To be implemented");
+}
+
+export async function unstable_saveFallbackAclFor(
+  dataset: LitDataset,
+  acl: unstable_Acl
+): Promise<unstable_Acl | null> {
+  throw new Error("To be implemented");
+}
+
+export function unstable_hasResourceAcl<Dataset extends unstable_Acl>(
+  dataset: Dataset
+): dataset is Dataset & {
+  acl: { resourceAcl: Exclude<unstable_Acl["acl"]["resourceAcl"], undefined> };
+} {
+  throw new Error("To be implemented");
+}
+
+export function unstable_getResourceAcl(
+  dataset: unstable_Acl & {
+    acl: {
+      resourceAcl: Exclude<unstable_Acl["acl"]["resourceAcl"], undefined>;
+    };
+  }
+): unstable_AclDataset;
+export function unstable_getResourceAcl(
+  dataset: unstable_Acl
+): unstable_AclDataset | null;
+export function unstable_getResourceAcl(
+  dataset: unstable_Acl
+): unstable_AclDataset | null {
+  throw new Error("To be implemented");
+}
+
+export function unstable_getFallbackAcl(
+  dataset: unstable_Acl
+): unstable_AclDataset {
+  throw new Error("To be implemented");
+}
+
+export function unstable_setResourceAcl(
+  dataset: LitDataset,
+  acl: unstable_AclDataset
+): LitDataset & unstable_Acl & { acl: ChangeLog } {
+  throw new Error("To be implemented");
+}
+
+export function unstable_getEffectiveAclRules(
+  dataset: DatasetInfo & unstable_Acl
+): unstable_AclRule[] {
+  // TODO: If there's a resourceAcl, return Things with type acl:Authorization and acl:accessTo = datasetUrl,
+  //       else, return Things with type acl:Authorization and acl:default !== null.
+  throw new Error("To be implemented");
+}
+
+export type unstable_AccessModes =
+  // If someone has write permissions, they also have append permissions:
+  | {
+      read: boolean;
+      append: true;
+      write: true;
+      control: boolean;
+    }
+  | {
+      read: boolean;
+      append: boolean;
+      write: false;
+      control: boolean;
+    };
+
+export function unstable_getAccessModes(
+  rule: unstable_AclRule
+): unstable_AccessModes {
+  throw new Error("To be implemented");
+}

--- a/src/acl.ts
+++ b/src/acl.ts
@@ -31,7 +31,7 @@ export async function unstable_saveFallbackAclFor(
   acl: unstable_Acl
 ): Promise<unstable_Acl | null> {
   // TODO: Implement this last, and only if we agree with both relevant teams that this is desirable.
-  //       See https://github.com/inrupt/lit-solid-core/pull/89/files/33f9fe5780877cd2764aae6fc62f2da6a4fe5569#r427773611
+  //       See https://github.com/inrupt/lit-solid/pull/89/files/33f9fe5780877cd2764aae6fc62f2da6a4fe5569#r427773611
   throw new Error("To be implemented");
 }
 

--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -1,0 +1,80 @@
+import {
+  WebId,
+  LitDataset,
+  unstable_Acl,
+  unstable_AclDataset,
+  unstable_AclRule,
+  ChangeLog,
+} from "../index";
+import { unstable_AccessModes } from "../acl";
+
+export type unstable_AgentAccess = Record<WebId, unstable_AccessModes>;
+
+export function unstable_getAgentAccessModesOne(
+  dataset: LitDataset & unstable_Acl,
+  agent: WebId
+): unstable_AccessModes {
+  throw new Error("To be implemented");
+}
+
+export function unstable_getAgentAccessModesAll(
+  dataset: LitDataset & unstable_Acl
+): unstable_AgentAccess {
+  throw new Error("To be implemented");
+}
+
+export function unstable_getAgentResourceAccessModesOne(
+  acl: unstable_AclDataset
+): unstable_AccessModes {
+  throw new Error("To be implemented");
+}
+
+export function unstable_getAgentResourceAccessModesAll(
+  acl: unstable_AclDataset
+): unstable_AgentAccess {
+  // TODO: Ensure that agents that are listed together in a single access rule are all included
+  throw new Error("To be implemented");
+}
+
+export function unstable_setAgentResourceAccessModes(
+  acl: unstable_AclDataset,
+  agent: WebId,
+  accessModes: unstable_AccessModes
+): unstable_AclDataset & ChangeLog {
+  throw new Error("To be implemented");
+}
+
+export function unstable_removeAgentResourceAccessModes(
+  acl: unstable_AclDataset,
+  agent: WebId
+): unstable_AclDataset & ChangeLog {
+  throw new Error("To be implemented");
+}
+
+export function unstable_getAgentDefaultAccessModesOne(
+  acl: unstable_AclDataset
+): unstable_AccessModes {
+  throw new Error("To be implemented");
+}
+
+export function unstable_getAgentDefaultAccessModesAll(
+  acl: unstable_AclDataset
+): unstable_AgentAccess {
+  // TODO: Ensure that agents that are listed together in a single access rule are all included
+  throw new Error("To be implemented");
+}
+
+export function unstable_setAgentDefaultAccessModes(
+  acl: unstable_AclDataset,
+  agent: WebId,
+  accessModes: unstable_AccessModes
+): unstable_AclDataset & ChangeLog {
+  throw new Error("To be implemented");
+}
+
+export function unstable_removeAgentDefaultAccessModes(
+  acl: unstable_AclDataset,
+  agent: WebId
+): unstable_AclDataset & ChangeLog {
+  throw new Error("To be implemented");
+}

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -8,6 +8,20 @@ import {
   saveLitDatasetAt,
 } from "./index";
 import { foaf, schema } from "rdf-namespaces";
+import { unstable_fetchLitDatasetWithAcl } from "./litDataset";
+// TODO: Import these from ./index:
+import {
+  unstable_getAgentAccessModesOne,
+  unstable_setAgentResourceAccessModes,
+  unstable_removeAgentResourceAccessModes,
+} from "./acl/agent";
+// TODO: Import these from ./index:
+import {
+  unstable_hasResourceAcl,
+  unstable_getResourceAcl,
+  unstable_setResourceAcl,
+  unstable_getFallbackAcl,
+} from "./acl";
 
 describe("End-to-end tests", () => {
   it("should be able to read and update data in a Pod", async () => {
@@ -46,5 +60,97 @@ describe("End-to-end tests", () => {
       "Thing for first end-to-end test"
     );
     expect(getStringUnlocalizedOne(savedThing, foaf.nick)).toBe(randomNick);
+  });
+
+  it("should be able to read and update ACLs", async () => {
+    const fakeWebId =
+      "https://example.com/fake-webid#" +
+      Date.now().toString() +
+      Math.random().toString();
+
+    const datasetWithAcl = await unstable_fetchLitDatasetWithAcl(
+      "https://lit-e2e-test.inrupt.net/public/lit-solid-core-acl-test/passthrough-container/resource-with-acl.ttl"
+    );
+    const datasetWithoutAcl = await unstable_fetchLitDatasetWithAcl(
+      "https://lit-e2e-test.inrupt.net/public/lit-solid-core-acl-test/passthrough-container/resource-without-acl.ttl"
+    );
+
+    expect(unstable_hasResourceAcl(datasetWithAcl)).toBe(true);
+    expect(unstable_hasResourceAcl(datasetWithoutAcl)).toBe(false);
+    expect(
+      unstable_getAgentAccessModesOne(
+        datasetWithAcl,
+        "https://vincentt.inrupt.net/profile/card#me"
+      )
+    ).toEqual({
+      read: true,
+      append: true,
+      write: false,
+      control: false,
+    });
+    expect(
+      unstable_getAgentAccessModesOne(
+        datasetWithoutAcl,
+        "https://vincentt.inrupt.net/profile/card#me"
+      )
+    ).toEqual({
+      read: true,
+      append: false,
+      write: false,
+      control: false,
+    });
+    const fallbackAclForDatasetWithoutAcl = unstable_getFallbackAcl(
+      datasetWithoutAcl
+    );
+    expect(fallbackAclForDatasetWithoutAcl.accessTo).toBe(
+      "https://lit-e2e-test.inrupt.net/public/lit-solid-core-acl-test/"
+    );
+
+    if (unstable_hasResourceAcl(datasetWithAcl)) {
+      const acl = unstable_getResourceAcl(datasetWithAcl);
+      const updatedAcl = unstable_setAgentResourceAccessModes(acl, fakeWebId, {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      });
+      const updatedDataset = unstable_setResourceAcl(
+        datasetWithAcl,
+        updatedAcl
+      );
+      await saveLitDatasetAt(
+        "https://lit-e2e-test.inrupt.net/public/lit-solid-core-acl-test/passthrough-container/resource-with-acl.ttl",
+        updatedDataset
+      );
+
+      const savedDatasetWithAcl = await unstable_fetchLitDatasetWithAcl(
+        "https://lit-e2e-test.inrupt.net/public/lit-solid-core-acl-test/passthrough-container/resource-with-acl.ttl"
+      );
+      const savedAcl = unstable_getResourceAcl(savedDatasetWithAcl);
+      const fakeWebIdAccess = unstable_getAgentAccessModesOne(
+        savedDatasetWithAcl,
+        fakeWebId
+      );
+      expect(fakeWebIdAccess).toEqual({
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      });
+
+      // Cleanup
+      const cleanedAcl = unstable_removeAgentResourceAccessModes(
+        savedAcl!,
+        fakeWebId
+      );
+      const cleanedDataset = unstable_setResourceAcl(
+        savedDatasetWithAcl,
+        cleanedAcl
+      );
+      await saveLitDatasetAt(
+        "https://lit-e2e-test.inrupt.net/public/lit-solid-core-acl-test/passthrough-container/resource-with-acl.ttl",
+        cleanedDataset
+      );
+    }
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ export {
  */
 export type Iri = NamedNode;
 export type IriString = string;
+export type WebId = IriString;
 
 /**
  * A LitDataset represents all Quads from a single Resource.
@@ -98,6 +99,11 @@ export type ThingLocal = Thing & { name: string };
  * Node's full IRI once it is persisted, where it will transform into a Named Node.
  */
 export type LocalNode = BlankNode & { name: string };
+
+export type unstable_AclDataset = LitDataset &
+  DatasetInfo & { accessTo: IriString };
+
+export type unstable_AclRule = Thing;
 
 type unstable_WacAllow = {
   user: {
@@ -143,6 +149,13 @@ export type ChangeLog = {
   };
 };
 
+export type unstable_Acl = {
+  acl: {
+    resourceAcl?: unstable_AclDataset;
+    fallbackAcl: unstable_AclDataset;
+  };
+};
+
 export function hasDatasetInfo<T extends LitDataset>(
   dataset: T
 ): dataset is T & DatasetInfo {
@@ -158,5 +171,19 @@ export function hasChangelog<T extends LitDataset>(
     typeof potentialChangeLog.changeLog === "object" &&
     Array.isArray(potentialChangeLog.changeLog.additions) &&
     Array.isArray(potentialChangeLog.changeLog.deletions)
+  );
+}
+
+export function unstable_hasAcl<T extends LitDataset>(
+  dataset: T
+): dataset is T & unstable_Acl {
+  const potentialAcl = dataset as T & unstable_Acl;
+  return (
+    typeof potentialAcl.acl === "object" &&
+    typeof potentialAcl.acl.fallbackAcl === "object" &&
+    hasDatasetInfo(potentialAcl.acl.fallbackAcl) &&
+    (typeof potentialAcl.acl.resourceAcl === "undefined" ||
+      (typeof potentialAcl.acl.resourceAcl === "object" &&
+        hasDatasetInfo(potentialAcl.acl.resourceAcl)))
   );
 }

--- a/src/litDataset.ts
+++ b/src/litDataset.ts
@@ -65,7 +65,7 @@ export async function fetchLitDataset(
 export async function unstable_fetchLitDatasetWithAcl(
   url: IriString,
   options: Partial<typeof defaultFetchOptions> = defaultFetchOptions
-): Promise<LitDataset & DatasetInfo & unstable_Acl> {
+): Promise<LitDataset & DatasetInfo & (unstable_Acl | { acl: null })> {
   throw new Error("To be implemented");
 }
 


### PR DESCRIPTION
This is not intended to be merged, as all the functions I've defined are not implemented. However, they demonstrate what the ACL-related API could look like, and will be my point of reference while implementing it.

We decided to just go ahead and implement something for now rather than go through the whole API review phase again, and all new functions are still marked as unstable, but in case anyone wants to see what it'll roughly look like after the first pass: this is the place.

The most relevant part is probably the new test in `src/e2e.test.ts`, which demonstrates how it could be used.