### PR TITLE
Re-enable running CI on all OS's

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         # Available OS's: https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
         node-version: [12.x, 10.x]
     steps:
     - uses: actions/checkout@v2.1.0


### PR DESCRIPTION
Now that we're public they're free again :)

This also switches to Ubuntu 20.04, which is currently still in
preview, but works fine and will likely soon be stable.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

Fixes #51.