### PR TITLE
Use consistent marker of inaccessible ACLs

### DIFF
--- a/src/litDataset.test.ts
+++ b/src/litDataset.test.ts
@@ -346,7 +346,7 @@ describe("fetchLitDatasetWithAcl", () => {
     ]);
   });
 
-  it("returns null for the ACL if the fetched Resource does not include a pointer to an ACL file", async () => {
+  it("does not attempt to fetch ACLs if the fetched Resource does not include a pointer to an ACL file, and sets an appropriate default value.", async () => {
     const mockFetch = jest.fn(window.fetch);
 
     mockFetch.mockReturnValueOnce(
@@ -365,7 +365,9 @@ describe("fetchLitDatasetWithAcl", () => {
       { fetch: mockFetch }
     );
 
-    expect(fetchedLitDataset.acl).toBeNull();
+    expect(mockFetch.mock.calls).toHaveLength(1);
+    expect(fetchedLitDataset.acl.resourceAcl).toBeUndefined();
+    expect(fetchedLitDataset.acl.fallbackAcl).toBeNull();
   });
 
   it("returns null for the Container ACL if the Container's ACL file could not be fetched", async () => {

--- a/src/litDataset.ts
+++ b/src/litDataset.ts
@@ -159,11 +159,16 @@ function parseDatasetInfo(response: Response): DatasetInfo["datasetInfo"] {
 export async function unstable_fetchLitDatasetWithAcl(
   url: UrlString,
   options: Partial<typeof defaultFetchOptions> = defaultFetchOptions
-): Promise<LitDataset & DatasetInfo & (unstable_Acl | { acl: null })> {
+): Promise<LitDataset & DatasetInfo & unstable_Acl> {
   const litDataset = await fetchLitDataset(url, options);
 
   if (!unstable_hasAccessibleAcl(litDataset)) {
-    return Object.assign(litDataset, { acl: null });
+    return Object.assign(litDataset, {
+      acl: {
+        resourceAcl: undefined,
+        fallbackAcl: null,
+      },
+    });
   }
 
   const [resourceAcl, fallbackAcl] = await Promise.all([


### PR DESCRIPTION
A LitDataset can have an `acl` object attached with the keys
`resourceAcl` and `fallbackAcl`, which are undefined and null
respectively if they are not found, the cause of which is usually
lack of Control access for the current user.

That will also result in the original Resource not even advertising
an ACL. In that case, the `acl` object as a whole was set to
`null`, meaning that the result could no longer be passed to
getAgentAccessModesOne/All without casting, even though that is
perfectly capable of dealing with inaccessible ACLs (it will just
return null).

(Specifically, I want Pod Manager to be able to get rid of [this cast](https://github.com/inrupt/pod-manager/blob/7e3ae1303587b637c5798c5cf69964f3a178cf4b/src/lit-solid-helpers/index.ts#L223).)

So now, if we can deduce from a Resource's metadata that neither
ACL file is going to be accessible anyway, we mark that in the same
way as we would mark it if we had tried to fetch those files and
_then_ found out that they were inaccessible.

<!-- When fixing a bug: -->

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
