### PR TITLE
Rename DatasetInfo to ResourceInfo

### DIFF
--- a/src/__snapshots__/litDataset.test.ts.snap
+++ b/src/__snapshots__/litDataset.test.ts.snap
@@ -2,9 +2,6 @@
 
 exports[`fetchLitDataset returns a LitDataset representing the fetched Turtle 1`] = `
 DatasetCore {
-  "datasetInfo": Object {
-    "fetchedFrom": "https://arbitrary.pod/resource",
-  },
   "quads": Set {
     Object {
       "graph": Object {
@@ -101,6 +98,9 @@ DatasetCore {
         "value": "https://arbitrary.pod/resource#me",
       },
     },
+  },
+  "resourceInfo": Object {
+    "fetchedFrom": "https://arbitrary.pod/resource",
   },
 }
 `;

--- a/src/acl.test.ts
+++ b/src/acl.test.ts
@@ -47,7 +47,7 @@ import {
   unstable_getFallbackAcl,
 } from "./acl";
 import {
-  DatasetInfo,
+  ResourceInfo,
   ThingPersisted,
   unstable_AclRule,
   unstable_AclDataset,
@@ -63,8 +63,8 @@ function mockResponse(
 
 describe("fetchResourceAcl", () => {
   it("returns the fetched ACL LitDataset", async () => {
-    const sourceDataset: DatasetInfo = {
-      datasetInfo: {
+    const sourceDataset: ResourceInfo = {
+      resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         unstable_aclUrl: "https://some.pod/resource.acl",
       },
@@ -82,7 +82,7 @@ describe("fetchResourceAcl", () => {
     });
 
     expect(fetchedAcl?.accessTo).toBe("https://some.pod/resource");
-    expect(fetchedAcl?.datasetInfo.fetchedFrom).toBe(
+    expect(fetchedAcl?.resourceInfo.fetchedFrom).toBe(
       "https://some.pod/resource.acl"
     );
     expect(mockFetch.mock.calls).toHaveLength(1);
@@ -90,8 +90,8 @@ describe("fetchResourceAcl", () => {
   });
 
   it("calls the included fetcher by default", async () => {
-    const sourceDataset: DatasetInfo = {
-      datasetInfo: {
+    const sourceDataset: ResourceInfo = {
+      resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         unstable_aclUrl: "https://some.pod/resource.acl",
       },
@@ -111,8 +111,8 @@ describe("fetchResourceAcl", () => {
   });
 
   it("returns null if the source LitDataset has no known ACL IRI", async () => {
-    const sourceDataset: DatasetInfo = {
-      datasetInfo: {
+    const sourceDataset: ResourceInfo = {
+      resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
       },
     };
@@ -123,8 +123,8 @@ describe("fetchResourceAcl", () => {
   });
 
   it("returns null if the ACL was not found", async () => {
-    const sourceDataset: DatasetInfo = {
-      datasetInfo: {
+    const sourceDataset: ResourceInfo = {
+      resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
         unstable_aclUrl: "https://some.pod/resource.acl",
       },
@@ -151,7 +151,7 @@ describe("fetchResourceAcl", () => {
 describe("fetchFallbackAcl", () => {
   it("returns the parent Container's ACL LitDataset, if present", async () => {
     const sourceDataset = {
-      datasetInfo: {
+      resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         // If no ACL IRI is given, the user does not have Control Access,
         // in which case we wouldn't be able to reliably determine the effective ACL.
@@ -178,7 +178,7 @@ describe("fetchFallbackAcl", () => {
     });
 
     expect(fetchedAcl?.accessTo).toBe("https://some.pod/");
-    expect(fetchedAcl?.datasetInfo.fetchedFrom).toBe("https://some.pod/.acl");
+    expect(fetchedAcl?.resourceInfo.fetchedFrom).toBe("https://some.pod/.acl");
     expect(mockFetch.mock.calls).toHaveLength(2);
     expect(mockFetch.mock.calls[0][0]).toBe("https://some.pod/");
     expect(mockFetch.mock.calls[1][0]).toBe("https://some.pod/.acl");
@@ -186,7 +186,7 @@ describe("fetchFallbackAcl", () => {
 
   it("calls the included fetcher by default", async () => {
     const sourceDataset = {
-      datasetInfo: {
+      resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         unstable_aclUrl: "https://some.pod/resource.acl",
       },
@@ -206,7 +206,7 @@ describe("fetchFallbackAcl", () => {
 
   it("travels up multiple levels if no ACL was found on the levels in between", async () => {
     const sourceDataset = {
-      datasetInfo: {
+      resourceInfo: {
         fetchedFrom: "https://some.pod/with-acl/without-acl/resource",
         // If no ACL IRI is given, the user does not have Control Access,
         // in which case we wouldn't be able to reliably determine the effective ACL.
@@ -254,7 +254,7 @@ describe("fetchFallbackAcl", () => {
     });
 
     expect(fetchedAcl?.accessTo).toBe("https://some.pod/with-acl/");
-    expect(fetchedAcl?.datasetInfo.fetchedFrom).toBe(
+    expect(fetchedAcl?.resourceInfo.fetchedFrom).toBe(
       "https://some.pod/with-acl/.acl"
     );
     expect(mockFetch.mock.calls).toHaveLength(4);
@@ -272,7 +272,7 @@ describe("fetchFallbackAcl", () => {
   // not be able to determine the effective ACL:
   it("returns null if one of the Containers on the way up does not advertise an ACL", async () => {
     const sourceDataset = {
-      datasetInfo: {
+      resourceInfo: {
         fetchedFrom:
           "https://some.pod/arbitrary-parent/no-control-access/resource",
         // If no ACL IRI is given, the user does not have Control Access,
@@ -303,7 +303,7 @@ describe("fetchFallbackAcl", () => {
 
   it("returns null if no ACL could be found for the Containers up to the root of the Pod", async () => {
     const sourceDataset = {
-      datasetInfo: {
+      resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         // If no ACL IRI is given, the user does not have Control Access,
         // in which case we wouldn't be able to reliably determine the effective ACL.
@@ -346,7 +346,7 @@ describe("getResourceAcl", () => {
   it("returns the attached Resource ACL Dataset", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
       accessTo: "https://arbitrary.pod/resource",
-      datasetInfo: { fetchedFrom: "https://arbitrary.pod/resource.acl" },
+      resourceInfo: { fetchedFrom: "https://arbitrary.pod/resource.acl" },
     });
     const litDataset = Object.assign(dataset(), {
       acl: { resourceAcl: aclDataset, fallbackAcl: null },
@@ -364,7 +364,7 @@ describe("getFallbackAcl", () => {
   it("returns the attached Fallback ACL Dataset", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
       accessTo: "https://arbitrary.pod/",
-      datasetInfo: { fetchedFrom: "https://arbitrary.pod/.acl" },
+      resourceInfo: { fetchedFrom: "https://arbitrary.pod/.acl" },
     });
     const litDataset = Object.assign(dataset(), {
       acl: { fallbackAcl: aclDataset },
@@ -381,7 +381,7 @@ describe("getFallbackAcl", () => {
 describe("getAclRules", () => {
   it("only returns Things that represent ACL Rules", () => {
     const aclDataset = Object.assign(dataset(), {
-      datasetInfo: { fetchedFrom: "https://arbitrary.pod/resource.acl" },
+      resourceInfo: { fetchedFrom: "https://arbitrary.pod/resource.acl" },
       accessTo: "https://arbitrary.pod/resource",
     });
 
@@ -467,7 +467,7 @@ describe("getAclRules", () => {
 
   it("returns Things with multiple `rdf:type`s, as long as at least on type is `acl:Authorization`", () => {
     const aclDataset = Object.assign(dataset(), {
-      datasetInfo: { fetchedFrom: "https://arbitrary.pod/resource.acl" },
+      resourceInfo: { fetchedFrom: "https://arbitrary.pod/resource.acl" },
       accessTo: "https://arbitrary.pod/resource",
     });
 

--- a/src/acl/agent.test.ts
+++ b/src/acl/agent.test.ts
@@ -34,13 +34,13 @@ import {
   LitDataset,
   unstable_AccessModes,
   unstable_Acl,
-  DatasetInfo,
+  ResourceInfo,
   IriString,
   unstable_AclDataset,
 } from "../interfaces";
 
 function addAclRuleQuads(
-  aclDataset: LitDataset & DatasetInfo,
+  aclDataset: LitDataset & ResourceInfo,
   agent: IriString,
   resource: IriString,
   accessModes: unstable_AccessModes,
@@ -113,10 +113,10 @@ function addAclRuleQuads(
 }
 
 function addAclDatasetToLitDataset(
-  litDataset: LitDataset & DatasetInfo,
+  litDataset: LitDataset & ResourceInfo,
   aclDataset: unstable_AclDataset,
   type: "resource" | "fallback"
-): LitDataset & DatasetInfo & unstable_Acl {
+): LitDataset & ResourceInfo & unstable_Acl {
   const acl: unstable_Acl["acl"] = {
     fallbackAcl: null,
     ...(((litDataset as any) as unstable_Acl).acl ?? {}),
@@ -129,9 +129,9 @@ function addAclDatasetToLitDataset(
   return Object.assign(litDataset, { acl: acl });
 }
 
-function getMockDataset(fetchedFrom: IriString): LitDataset & DatasetInfo {
+function getMockDataset(fetchedFrom: IriString): LitDataset & ResourceInfo {
   return Object.assign(dataset(), {
-    datasetInfo: {
+    resourceInfo: {
       fetchedFrom: fetchedFrom,
     },
   });

--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -20,7 +20,7 @@
  */
 
 import {
-  DatasetInfo,
+  ResourceInfo,
   LitDataset,
   WebId,
   unstable_Acl,
@@ -56,7 +56,7 @@ export type unstable_AgentAccess = Record<WebId, unstable_AccessModes>;
  * @returns Which Access Modes have been granted to the Agent specifically for the given LitDataset, or `null` if it could not be determined (e.g. because the current user does not have Control Access to a given Resource or its Container).
  */
 export function unstable_getAgentAccessModesOne(
-  dataset: LitDataset & DatasetInfo & unstable_Acl,
+  dataset: LitDataset & ResourceInfo & unstable_Acl,
   agent: WebId
 ): unstable_AccessModes | null {
   if (unstable_hasResourceAcl(dataset)) {
@@ -81,7 +81,7 @@ export function unstable_getAgentAccessModesOne(
  * @returns Which Access Modes have been granted to which Agents specifically for the given LitDataset, or `null` if it could not be determined (e.g. because the current user does not have Control Access to a given Resource or its Container).
  */
 export function unstable_getAgentAccessModesAll(
-  dataset: LitDataset & DatasetInfo & unstable_Acl
+  dataset: LitDataset & ResourceInfo & unstable_Acl
 ): unstable_AgentAccess | null {
   if (unstable_hasResourceAcl(dataset)) {
     const resourceAcl = unstable_getResourceAcl(dataset);

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,7 @@ export {
   ThingPersisted,
   ThingLocal,
   LocalNode,
-  DatasetInfo,
+  ResourceInfo,
   ChangeLog,
   unstable_Acl,
   unstable_AclDataset,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -72,7 +72,7 @@ export type LocalNode = BlankNode & { name: string };
  * function is still experimental and can change in a non-major release.
  */
 export type unstable_AclDataset = LitDataset &
-  DatasetInfo & { accessTo: UrlString };
+  ResourceInfo & { accessTo: UrlString };
 
 /**
  * @hidden Developers shouldn't need to directly access ACL rules. Instead, we provide our own functions that verify what access someone has.
@@ -107,8 +107,8 @@ type unstable_WacAllow = {
 /**
  * [[LitDataset]]s fetched by lit-pod include this metadata describing its relation to a Pod Resource.
  */
-export type DatasetInfo = {
-  datasetInfo: {
+export type ResourceInfo = {
+  resourceInfo: {
     fetchedFrom: UrlString;
     /**
      * The URL reported by the server as possibly containing an ACL file. Note that this file might
@@ -156,11 +156,11 @@ export type unstable_Acl = {
  * @param dataset A [[LitDataset]] that may have metadata attached about the Resource it was retrieved from.
  * @returns True if `dataset` includes metadata about the Resource it was retrieved from, false if not.
  */
-export function hasDatasetInfo<T extends LitDataset>(
+export function hasResourceInfo<T extends LitDataset>(
   dataset: T
-): dataset is T & DatasetInfo {
-  const potentialDatasetInfo = dataset as T & DatasetInfo;
-  return typeof potentialDatasetInfo.datasetInfo === "object";
+): dataset is T & ResourceInfo {
+  const potentialResourceInfo = dataset as T & ResourceInfo;
+  return typeof potentialResourceInfo.resourceInfo === "object";
 }
 
 /** @internal */
@@ -185,12 +185,12 @@ export function hasChangelog<T extends LitDataset>(
  * @returns Whether the given `dataset` has ACL data attached to it.
  * @internal
  */
-export function unstable_hasAccessibleAcl<Dataset extends DatasetInfo>(
+export function unstable_hasAccessibleAcl<Dataset extends ResourceInfo>(
   dataset: Dataset
 ): dataset is Dataset & {
-  datasetInfo: { unstable_aclUrl: UrlString };
+  resourceInfo: { unstable_aclUrl: UrlString };
 } {
-  return typeof dataset.datasetInfo.unstable_aclUrl === "string";
+  return typeof dataset.resourceInfo.unstable_aclUrl === "string";
 }
 
 /**

--- a/src/litDataset.test.ts
+++ b/src/litDataset.test.ts
@@ -38,12 +38,12 @@ import {
   saveLitDatasetAt,
   saveLitDatasetInContainer,
   unstable_fetchLitDatasetWithAcl,
-  internal_fetchLitDatasetInfo,
+  internal_fetchResourceInfo,
   createLitDataset,
 } from "./litDataset";
 import {
   ChangeLog,
-  DatasetInfo,
+  ResourceInfo,
   IriString,
   LitDataset,
   LocalNode,
@@ -103,7 +103,7 @@ describe("fetchLitDataset", () => {
       fetch: mockFetch,
     });
 
-    expect(litDataset.datasetInfo.fetchedFrom).toBe(
+    expect(litDataset.resourceInfo.fetchedFrom).toBe(
       "https://some.pod/resource"
     );
   });
@@ -125,7 +125,7 @@ describe("fetchLitDataset", () => {
       { fetch: mockFetch }
     );
 
-    expect(litDataset.datasetInfo.unstable_aclUrl).toBe(
+    expect(litDataset.resourceInfo.unstable_aclUrl).toBe(
       "https://some.pod/container/aclresource.acl"
     );
   });
@@ -146,7 +146,7 @@ describe("fetchLitDataset", () => {
       { fetch: mockFetch }
     );
 
-    expect(litDataset.datasetInfo.unstable_aclUrl).toBeUndefined();
+    expect(litDataset.resourceInfo.unstable_aclUrl).toBeUndefined();
   });
 
   it("provides the relevant access permissions to the Resource, if available", async () => {
@@ -165,7 +165,7 @@ describe("fetchLitDataset", () => {
       { fetch: mockFetch }
     );
 
-    expect(litDataset.datasetInfo.unstable_permissions).toEqual({
+    expect(litDataset.resourceInfo.unstable_permissions).toEqual({
       user: {
         read: true,
         append: true,
@@ -198,7 +198,7 @@ describe("fetchLitDataset", () => {
       { fetch: mockFetch }
     );
 
-    expect(litDataset.datasetInfo.unstable_permissions).toEqual({
+    expect(litDataset.resourceInfo.unstable_permissions).toEqual({
       user: {
         read: false,
         append: false,
@@ -228,7 +228,7 @@ describe("fetchLitDataset", () => {
       { fetch: mockFetch }
     );
 
-    expect(litDataset.datasetInfo.unstable_permissions).toBeUndefined();
+    expect(litDataset.resourceInfo.unstable_permissions).toBeUndefined();
   });
 
   it("returns a LitDataset representing the fetched Turtle", async () => {
@@ -315,13 +315,13 @@ describe("fetchLitDatasetWithAcl", () => {
       { fetch: mockFetch }
     );
 
-    expect(fetchedLitDataset.datasetInfo.fetchedFrom).toBe(
+    expect(fetchedLitDataset.resourceInfo.fetchedFrom).toBe(
       "https://some.pod/resource"
     );
-    expect(fetchedLitDataset.acl?.resourceAcl?.datasetInfo.fetchedFrom).toBe(
+    expect(fetchedLitDataset.acl?.resourceAcl?.resourceInfo.fetchedFrom).toBe(
       "https://some.pod/resource.acl"
     );
-    expect(fetchedLitDataset.acl?.fallbackAcl?.datasetInfo.fetchedFrom).toBe(
+    expect(fetchedLitDataset.acl?.fallbackAcl?.resourceInfo.fetchedFrom).toBe(
       "https://some.pod/.acl"
     );
     expect(mockFetch.mock.calls).toHaveLength(4);
@@ -393,7 +393,7 @@ describe("fetchLitDatasetWithAcl", () => {
 
     expect(fetchedLitDataset.acl).not.toBeNull();
     expect(fetchedLitDataset.acl?.fallbackAcl).toBeNull();
-    expect(fetchedLitDataset.acl?.resourceAcl?.datasetInfo.fetchedFrom).toBe(
+    expect(fetchedLitDataset.acl?.resourceAcl?.resourceInfo.fetchedFrom).toBe(
       "https://some.pod/resource.acl"
     );
   });
@@ -429,7 +429,7 @@ describe("fetchLitDatasetWithAcl", () => {
     );
 
     expect(fetchedLitDataset.acl?.resourceAcl).toBeUndefined();
-    expect(fetchedLitDataset.acl?.fallbackAcl?.datasetInfo.fetchedFrom).toBe(
+    expect(fetchedLitDataset.acl?.fallbackAcl?.resourceInfo.fetchedFrom).toBe(
       "https://some.pod/.acl"
     );
   });
@@ -473,7 +473,7 @@ describe("fetchLitDatasetWithAcl", () => {
   });
 });
 
-describe("fetchLitDatasetInfo", () => {
+describe("fetchResourceInfo", () => {
   it("calls the included fetcher by default", async () => {
     const mockedFetcher = jest.requireMock("./fetcher.ts") as {
       fetch: jest.Mock<
@@ -482,7 +482,7 @@ describe("fetchLitDatasetInfo", () => {
       >;
     };
 
-    await internal_fetchLitDatasetInfo("https://some.pod/resource");
+    await internal_fetchResourceInfo("https://some.pod/resource");
 
     expect(mockedFetcher.fetch.mock.calls).toHaveLength(1);
     expect(mockedFetcher.fetch.mock.calls[0][0]).toBe(
@@ -495,7 +495,7 @@ describe("fetchLitDatasetInfo", () => {
       .fn(window.fetch)
       .mockReturnValue(Promise.resolve(new Response()));
 
-    await internal_fetchLitDatasetInfo("https://some.pod/resource", {
+    await internal_fetchResourceInfo("https://some.pod/resource", {
       fetch: mockFetch,
     });
 
@@ -512,14 +512,14 @@ describe("fetchLitDatasetInfo", () => {
         )
       );
 
-    const litDataset = await internal_fetchLitDatasetInfo(
+    const litDataset = await internal_fetchResourceInfo(
       "https://some.pod/resource",
       {
         fetch: mockFetch,
       }
     );
 
-    expect(litDataset.datasetInfo.fetchedFrom).toBe(
+    expect(litDataset.resourceInfo.fetchedFrom).toBe(
       "https://some.pod/resource"
     );
   });
@@ -536,12 +536,12 @@ describe("fetchLitDatasetInfo", () => {
       )
     );
 
-    const litDataset = await internal_fetchLitDatasetInfo(
+    const litDataset = await internal_fetchResourceInfo(
       "https://some.pod/container/resource",
       { fetch: mockFetch }
     );
 
-    expect(litDataset.datasetInfo.unstable_aclUrl).toBe(
+    expect(litDataset.resourceInfo.unstable_aclUrl).toBe(
       "https://some.pod/container/aclresource.acl"
     );
   });
@@ -557,12 +557,12 @@ describe("fetchLitDatasetInfo", () => {
       )
     );
 
-    const litDataset = await internal_fetchLitDatasetInfo(
+    const litDataset = await internal_fetchResourceInfo(
       "https://some.pod/container/resource",
       { fetch: mockFetch }
     );
 
-    expect(litDataset.datasetInfo.unstable_aclUrl).toBeUndefined();
+    expect(litDataset.resourceInfo.unstable_aclUrl).toBeUndefined();
   });
 
   it("provides the relevant access permissions to the Resource, if available", async () => {
@@ -576,12 +576,12 @@ describe("fetchLitDatasetInfo", () => {
       )
     );
 
-    const litDataset = await internal_fetchLitDatasetInfo(
+    const litDataset = await internal_fetchResourceInfo(
       "https://arbitrary.pod/container/resource",
       { fetch: mockFetch }
     );
 
-    expect(litDataset.datasetInfo.unstable_permissions).toEqual({
+    expect(litDataset.resourceInfo.unstable_permissions).toEqual({
       user: {
         read: true,
         append: true,
@@ -609,12 +609,12 @@ describe("fetchLitDatasetInfo", () => {
       )
     );
 
-    const litDataset = await internal_fetchLitDatasetInfo(
+    const litDataset = await internal_fetchResourceInfo(
       "https://arbitrary.pod/container/resource",
       { fetch: mockFetch }
     );
 
-    expect(litDataset.datasetInfo.unstable_permissions).toEqual({
+    expect(litDataset.resourceInfo.unstable_permissions).toEqual({
       user: {
         read: false,
         append: false,
@@ -639,12 +639,12 @@ describe("fetchLitDatasetInfo", () => {
       )
     );
 
-    const litDataset = await internal_fetchLitDatasetInfo(
+    const litDataset = await internal_fetchResourceInfo(
       "https://arbitrary.pod/container/resource",
       { fetch: mockFetch }
     );
 
-    expect(litDataset.datasetInfo.unstable_permissions).toBeUndefined();
+    expect(litDataset.resourceInfo.unstable_permissions).toBeUndefined();
   });
 
   it("does not request the actual data from the server", async () => {
@@ -656,7 +656,7 @@ describe("fetchLitDatasetInfo", () => {
         )
       );
 
-    await internal_fetchLitDatasetInfo("https://some.pod/resource", {
+    await internal_fetchResourceInfo("https://some.pod/resource", {
       fetch: mockFetch,
     });
 
@@ -672,7 +672,7 @@ describe("fetchLitDatasetInfo", () => {
         Promise.resolve(new Response("Not allowed", { status: 403 }))
       );
 
-    const fetchPromise = internal_fetchLitDatasetInfo(
+    const fetchPromise = internal_fetchResourceInfo(
       "https://arbitrary.pod/resource",
       {
         fetch: mockFetch,
@@ -691,7 +691,7 @@ describe("fetchLitDatasetInfo", () => {
         Promise.resolve(new Response("Not found", { status: 404 }))
       );
 
-    const fetchPromise = internal_fetchLitDatasetInfo(
+    const fetchPromise = internal_fetchResourceInfo(
       "https://arbitrary.pod/resource",
       {
         fetch: mockFetch,
@@ -903,7 +903,7 @@ describe("saveLitDatasetAt", () => {
     function getMockUpdatedDataset(
       changeLog: ChangeLog["changeLog"],
       fromUrl: IriString
-    ): LitDataset & ChangeLog & DatasetInfo {
+    ): LitDataset & ChangeLog & ResourceInfo {
       const mockDataset = dataset();
       mockDataset.add(
         DataFactory.quad(
@@ -918,13 +918,13 @@ describe("saveLitDatasetAt", () => {
         mockDataset.add(tripleToAdd)
       );
 
-      const datasetInfo: DatasetInfo["datasetInfo"] = {
+      const resourceInfo: ResourceInfo["resourceInfo"] = {
         fetchedFrom: fromUrl,
       };
 
       return Object.assign(mockDataset, {
         changeLog: changeLog,
-        datasetInfo: datasetInfo,
+        resourceInfo: resourceInfo,
       });
     }
 
@@ -1395,7 +1395,7 @@ describe("saveLitDatasetInContainer", () => {
       }
     );
 
-    expect(savedLitDataset.datasetInfo.fetchedFrom).toBe(
+    expect(savedLitDataset.resourceInfo.fetchedFrom).toBe(
       "https://some.pod/container/resource"
     );
   });
@@ -1458,7 +1458,7 @@ describe("saveLitDatasetInContainer", () => {
       }
     );
 
-    expect(savedLitDataset.datasetInfo.fetchedFrom).toBe(
+    expect(savedLitDataset.resourceInfo.fetchedFrom).toBe(
       "https://some.pod/container/resource"
     );
   });

--- a/src/thing.test.ts
+++ b/src/thing.test.ts
@@ -37,7 +37,7 @@ import {
   ThingLocal,
   ThingPersisted,
   LitDataset,
-  DatasetInfo,
+  ResourceInfo,
   ChangeLog,
 } from "./interfaces";
 
@@ -580,10 +580,10 @@ describe("setThing", () => {
       subject: "https://some.pod/resource#subject",
       object: "https://some.vocab/old-object",
     });
-    const datasetWithNamedNode: LitDataset & DatasetInfo = Object.assign(
+    const datasetWithNamedNode: LitDataset & ResourceInfo = Object.assign(
       dataset(),
       {
-        datasetInfo: { fetchedFrom: "https://some.pod/resource" },
+        resourceInfo: { fetchedFrom: "https://some.pod/resource" },
       }
     );
     datasetWithNamedNode.add(oldThingQuad);
@@ -621,10 +621,10 @@ describe("setThing", () => {
       mockPredicate,
       DataFactory.namedNode("https://some.vocab/new-object")
     );
-    const datasetWithLocalSubject: LitDataset & DatasetInfo = Object.assign(
+    const datasetWithLocalSubject: LitDataset & ResourceInfo = Object.assign(
       dataset(),
       {
-        datasetInfo: { fetchedFrom: "https://some.pod/resource" },
+        resourceInfo: { fetchedFrom: "https://some.pod/resource" },
       }
     );
     datasetWithLocalSubject.add(oldThingQuad);
@@ -882,10 +882,10 @@ describe("removeThing", () => {
       subject: "https://some.pod/resource#subject",
       object: "https://some.vocab/old-object",
     });
-    const datasetWithNamedNode: LitDataset & DatasetInfo = Object.assign(
+    const datasetWithNamedNode: LitDataset & ResourceInfo = Object.assign(
       dataset(),
       {
-        datasetInfo: { fetchedFrom: "https://some.pod/resource" },
+        resourceInfo: { fetchedFrom: "https://some.pod/resource" },
       }
     );
     datasetWithNamedNode.add(oldThingQuad);
@@ -913,10 +913,10 @@ describe("removeThing", () => {
       mockPredicate,
       DataFactory.namedNode("https://some.vocab/new-object")
     );
-    const datasetWithLocalNode: LitDataset & DatasetInfo = Object.assign(
+    const datasetWithLocalNode: LitDataset & ResourceInfo = Object.assign(
       dataset(),
       {
-        datasetInfo: { fetchedFrom: "https://some.pod/resource" },
+        resourceInfo: { fetchedFrom: "https://some.pod/resource" },
       }
     );
     datasetWithLocalNode.add(thingQuad);

--- a/src/thing.ts
+++ b/src/thing.ts
@@ -38,9 +38,9 @@ import {
   LocalNode,
   ThingPersisted,
   ChangeLog,
-  DatasetInfo,
+  ResourceInfo,
   hasChangelog,
-  hasDatasetInfo,
+  hasResourceInfo,
 } from "./interfaces";
 
 /**
@@ -159,8 +159,8 @@ export function removeThing<Dataset extends LitDataset>(
   thing: UrlString | Url | LocalNode | Thing
 ): Dataset & ChangeLog {
   const newLitDataset = withChangeLog(cloneLitStructs(litDataset));
-  const resourceIri: UrlString | undefined = hasDatasetInfo(newLitDataset)
-    ? newLitDataset.datasetInfo.fetchedFrom
+  const resourceIri: UrlString | undefined = hasResourceInfo(newLitDataset)
+    ? newLitDataset.resourceInfo.fetchedFrom
     : undefined;
 
   const thingSubject = toNode(thing);
@@ -200,9 +200,9 @@ function cloneLitStructs<Dataset extends LitDataset>(
       deletions: [...litDataset.changeLog.deletions],
     };
   }
-  if (hasDatasetInfo(litDataset)) {
-    (freshDataset as LitDataset & DatasetInfo).datasetInfo = {
-      ...litDataset.datasetInfo,
+  if (hasResourceInfo(litDataset)) {
+    (freshDataset as LitDataset & ResourceInfo).resourceInfo = {
+      ...litDataset.resourceInfo,
     };
   }
 


### PR DESCRIPTION
The reason for this is that the info in there is not just
applicable to LitDatasets, but also to other Resources, and will
therefore likely be re-used for those.

This is technically a breaking change (not that we've released v1 anyway, but still). However, Pod Manager only uses it once, and that is in a cast that should no longer be necessary with #157.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

Fixes #156.