### PR TITLE
Rename StringUnlocalized

### DIFF
--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -24,9 +24,9 @@ import {
   fetchLitDataset,
   setThing,
   getThingOne,
-  getStringUnlocalizedOne,
+  getStringNoLocaleOne,
   setDatetime,
-  setStringUnlocalized,
+  setStringNoLocale,
   saveLitDatasetAt,
 } from "./index";
 
@@ -42,7 +42,7 @@ describe("End-to-end tests", () => {
       "https://lit-e2e-test.inrupt.net/public/lit-pod-test.ttl#thing1"
     );
 
-    expect(getStringUnlocalizedOne(existingThing, foaf.name)).toBe(
+    expect(getStringNoLocaleOne(existingThing, foaf.name)).toBe(
       "Thing for first end-to-end test"
     );
 
@@ -51,7 +51,7 @@ describe("End-to-end tests", () => {
       schema.dateModified,
       new Date()
     );
-    updatedThing = setStringUnlocalized(updatedThing, foaf.nick, randomNick);
+    updatedThing = setStringNoLocale(updatedThing, foaf.nick, randomNick);
 
     const updatedDataset = setThing(dataset, updatedThing);
     const savedDataset = await saveLitDatasetAt(
@@ -63,9 +63,9 @@ describe("End-to-end tests", () => {
       savedDataset,
       "https://lit-e2e-test.inrupt.net/public/lit-pod-test.ttl#thing1"
     );
-    expect(getStringUnlocalizedOne(savedThing, foaf.name)).toBe(
+    expect(getStringNoLocaleOne(savedThing, foaf.name)).toBe(
       "Thing for first end-to-end test"
     );
-    expect(getStringUnlocalizedOne(savedThing, foaf.nick)).toBe(randomNick);
+    expect(getStringNoLocaleOne(savedThing, foaf.nick)).toBe(randomNick);
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -42,7 +42,7 @@ import {
   getDecimalOne,
   getIntegerOne,
   getStringInLocaleOne,
-  getStringUnlocalizedOne,
+  getStringNoLocaleOne,
   getUrlAll,
   getIriAll,
   getBooleanAll,
@@ -50,7 +50,7 @@ import {
   getDecimalAll,
   getIntegerAll,
   getStringInLocaleAll,
-  getStringUnlocalizedAll,
+  getStringNoLocaleAll,
   getLiteralOne,
   getNamedNodeOne,
   getLiteralAll,
@@ -62,7 +62,7 @@ import {
   addDecimal,
   addInteger,
   addStringInLocale,
-  addStringUnlocalized,
+  addStringNoLocale,
   addLiteral,
   addNamedNode,
   setUrl,
@@ -72,7 +72,7 @@ import {
   setDecimal,
   setInteger,
   setStringInLocale,
-  setStringUnlocalized,
+  setStringNoLocale,
   setLiteral,
   setNamedNode,
   removeAll,
@@ -83,7 +83,7 @@ import {
   removeDecimal,
   removeInteger,
   removeStringInLocale,
-  removeStringUnlocalized,
+  removeStringNoLocale,
   removeLiteral,
   removeNamedNode,
   unstable_fetchLitDatasetWithAcl,
@@ -97,6 +97,12 @@ import {
   unstable_getAgentResourceAccessModesAll,
   unstable_getAgentDefaultAccessModesOne,
   unstable_getAgentDefaultAccessModesAll,
+  // Deprecated functions still exported for backwards compatibility:
+  getStringUnlocalizedOne,
+  getStringUnlocalizedAll,
+  addStringUnlocalized,
+  setStringUnlocalized,
+  removeStringUnlocalized,
 } from "./index";
 
 // These tests aren't too useful in preventing bugs, but they work around this issue:
@@ -124,7 +130,7 @@ it("exports the public API from the entry file", () => {
   expect(getDecimalOne).toBeDefined();
   expect(getIntegerOne).toBeDefined();
   expect(getStringInLocaleOne).toBeDefined();
-  expect(getStringUnlocalizedOne).toBeDefined();
+  expect(getStringNoLocaleOne).toBeDefined();
   expect(getUrlAll).toBeDefined();
   expect(getIriAll).toBeDefined();
   expect(getBooleanAll).toBeDefined();
@@ -132,7 +138,7 @@ it("exports the public API from the entry file", () => {
   expect(getDecimalAll).toBeDefined();
   expect(getIntegerAll).toBeDefined();
   expect(getStringInLocaleAll).toBeDefined();
-  expect(getStringUnlocalizedAll).toBeDefined();
+  expect(getStringNoLocaleAll).toBeDefined();
   expect(getLiteralOne).toBeDefined();
   expect(getNamedNodeOne).toBeDefined();
   expect(getLiteralAll).toBeDefined();
@@ -144,7 +150,7 @@ it("exports the public API from the entry file", () => {
   expect(addDecimal).toBeDefined();
   expect(addInteger).toBeDefined();
   expect(addStringInLocale).toBeDefined();
-  expect(addStringUnlocalized).toBeDefined();
+  expect(addStringNoLocale).toBeDefined();
   expect(addLiteral).toBeDefined();
   expect(addNamedNode).toBeDefined();
   expect(setUrl).toBeDefined();
@@ -154,7 +160,7 @@ it("exports the public API from the entry file", () => {
   expect(setDecimal).toBeDefined();
   expect(setInteger).toBeDefined();
   expect(setStringInLocale).toBeDefined();
-  expect(setStringUnlocalized).toBeDefined();
+  expect(setStringNoLocale).toBeDefined();
   expect(setLiteral).toBeDefined();
   expect(setNamedNode).toBeDefined();
   expect(removeAll).toBeDefined();
@@ -165,7 +171,7 @@ it("exports the public API from the entry file", () => {
   expect(removeDecimal).toBeDefined();
   expect(removeInteger).toBeDefined();
   expect(removeStringInLocale).toBeDefined();
-  expect(removeStringUnlocalized).toBeDefined();
+  expect(removeStringNoLocale).toBeDefined();
   expect(removeLiteral).toBeDefined();
   expect(removeNamedNode).toBeDefined();
   expect(unstable_fetchLitDatasetWithAcl).toBeDefined();
@@ -179,4 +185,12 @@ it("exports the public API from the entry file", () => {
   expect(unstable_getAgentResourceAccessModesAll).toBeDefined();
   expect(unstable_getAgentDefaultAccessModesOne).toBeDefined();
   expect(unstable_getAgentDefaultAccessModesAll).toBeDefined();
+});
+
+it("still exports deprecated methods", () => {
+  expect(getStringUnlocalizedOne).toBeDefined();
+  expect(getStringUnlocalizedAll).toBeDefined();
+  expect(addStringUnlocalized).toBeDefined();
+  expect(setStringUnlocalized).toBeDefined();
+  expect(removeStringUnlocalized).toBeDefined();
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -41,7 +41,7 @@ import {
   getDatetimeOne,
   getDecimalOne,
   getIntegerOne,
-  getStringInLocaleOne,
+  getStringWithLocaleOne,
   getStringNoLocaleOne,
   getUrlAll,
   getIriAll,
@@ -49,7 +49,7 @@ import {
   getDatetimeAll,
   getDecimalAll,
   getIntegerAll,
-  getStringInLocaleAll,
+  getStringWithLocaleAll,
   getStringNoLocaleAll,
   getLiteralOne,
   getNamedNodeOne,
@@ -61,7 +61,7 @@ import {
   addDatetime,
   addDecimal,
   addInteger,
-  addStringInLocale,
+  addStringWithLocale,
   addStringNoLocale,
   addLiteral,
   addNamedNode,
@@ -71,7 +71,7 @@ import {
   setDatetime,
   setDecimal,
   setInteger,
-  setStringInLocale,
+  setStringWithLocale,
   setStringNoLocale,
   setLiteral,
   setNamedNode,
@@ -82,7 +82,7 @@ import {
   removeDatetime,
   removeDecimal,
   removeInteger,
-  removeStringInLocale,
+  removeStringWithLocale,
   removeStringNoLocale,
   removeLiteral,
   removeNamedNode,
@@ -103,6 +103,11 @@ import {
   addStringUnlocalized,
   setStringUnlocalized,
   removeStringUnlocalized,
+  getStringInLocaleOne,
+  getStringInLocaleAll,
+  addStringInLocale,
+  setStringInLocale,
+  removeStringInLocale,
 } from "./index";
 
 // These tests aren't too useful in preventing bugs, but they work around this issue:
@@ -129,7 +134,7 @@ it("exports the public API from the entry file", () => {
   expect(getDatetimeOne).toBeDefined();
   expect(getDecimalOne).toBeDefined();
   expect(getIntegerOne).toBeDefined();
-  expect(getStringInLocaleOne).toBeDefined();
+  expect(getStringWithLocaleOne).toBeDefined();
   expect(getStringNoLocaleOne).toBeDefined();
   expect(getUrlAll).toBeDefined();
   expect(getIriAll).toBeDefined();
@@ -137,7 +142,7 @@ it("exports the public API from the entry file", () => {
   expect(getDatetimeAll).toBeDefined();
   expect(getDecimalAll).toBeDefined();
   expect(getIntegerAll).toBeDefined();
-  expect(getStringInLocaleAll).toBeDefined();
+  expect(getStringWithLocaleAll).toBeDefined();
   expect(getStringNoLocaleAll).toBeDefined();
   expect(getLiteralOne).toBeDefined();
   expect(getNamedNodeOne).toBeDefined();
@@ -149,7 +154,7 @@ it("exports the public API from the entry file", () => {
   expect(addDatetime).toBeDefined();
   expect(addDecimal).toBeDefined();
   expect(addInteger).toBeDefined();
-  expect(addStringInLocale).toBeDefined();
+  expect(addStringWithLocale).toBeDefined();
   expect(addStringNoLocale).toBeDefined();
   expect(addLiteral).toBeDefined();
   expect(addNamedNode).toBeDefined();
@@ -159,7 +164,7 @@ it("exports the public API from the entry file", () => {
   expect(setDatetime).toBeDefined();
   expect(setDecimal).toBeDefined();
   expect(setInteger).toBeDefined();
-  expect(setStringInLocale).toBeDefined();
+  expect(setStringWithLocale).toBeDefined();
   expect(setStringNoLocale).toBeDefined();
   expect(setLiteral).toBeDefined();
   expect(setNamedNode).toBeDefined();
@@ -170,7 +175,7 @@ it("exports the public API from the entry file", () => {
   expect(removeDatetime).toBeDefined();
   expect(removeDecimal).toBeDefined();
   expect(removeInteger).toBeDefined();
-  expect(removeStringInLocale).toBeDefined();
+  expect(removeStringWithLocale).toBeDefined();
   expect(removeStringNoLocale).toBeDefined();
   expect(removeLiteral).toBeDefined();
   expect(removeNamedNode).toBeDefined();
@@ -188,9 +193,14 @@ it("exports the public API from the entry file", () => {
 });
 
 it("still exports deprecated methods", () => {
+  expect(getStringInLocaleOne).toBeDefined();
   expect(getStringUnlocalizedOne).toBeDefined();
+  expect(getStringInLocaleAll).toBeDefined();
   expect(getStringUnlocalizedAll).toBeDefined();
+  expect(addStringInLocale).toBeDefined();
   expect(addStringUnlocalized).toBeDefined();
+  expect(setStringInLocale).toBeDefined();
   expect(setStringUnlocalized).toBeDefined();
+  expect(removeStringInLocale).toBeDefined();
   expect(removeStringUnlocalized).toBeDefined();
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ export {
   getDecimalOne,
   getIntegerOne,
   getStringInLocaleOne,
-  getStringUnlocalizedOne,
+  getStringNoLocaleOne,
   getUrlAll,
   getIriAll,
   getBooleanAll,
@@ -57,11 +57,16 @@ export {
   getDecimalAll,
   getIntegerAll,
   getStringInLocaleAll,
-  getStringUnlocalizedAll,
+  getStringNoLocaleAll,
   getLiteralOne,
   getNamedNodeOne,
   getLiteralAll,
   getNamedNodeAll,
+  // Aliases for deprecated exports to preserve backwards compatibility:
+  /** @deprecated See [[getStringNoLocaleOne]] */
+  getStringNoLocaleOne as getStringUnlocalizedOne,
+  /** @deprecated See [[getStringNoLocaleAll]] */
+  getStringNoLocaleAll as getStringUnlocalizedAll,
 } from "./thing/get";
 export {
   addUrl,
@@ -71,9 +76,12 @@ export {
   addDecimal,
   addInteger,
   addStringInLocale,
-  addStringUnlocalized,
+  addStringNoLocale,
   addLiteral,
   addNamedNode,
+  // Aliases for deprecated exports to preserve backwards compatibility:
+  /** @deprecated See [[addStringNoLocale]] */
+  addStringNoLocale as addStringUnlocalized,
 } from "./thing/add";
 export {
   setUrl,
@@ -83,9 +91,12 @@ export {
   setDecimal,
   setInteger,
   setStringInLocale,
-  setStringUnlocalized,
+  setStringNoLocale,
   setLiteral,
   setNamedNode,
+  // Aliases for deprecated exports to preserve backwards compatibility:
+  /** @deprecated See [[setStringNoLocale]] */
+  setStringNoLocale as setStringUnlocalized,
 } from "./thing/set";
 export {
   removeAll,
@@ -96,9 +107,12 @@ export {
   removeDecimal,
   removeInteger,
   removeStringInLocale,
-  removeStringUnlocalized,
+  removeStringNoLocale,
   removeLiteral,
   removeNamedNode,
+  // Aliases for deprecated exports to preserve backwards compatibility:
+  /** @deprecated See [[removeStringNoLocale]] */
+  removeStringNoLocale as removeStringUnlocalized,
 } from "./thing/remove";
 export {
   unstable_hasFallbackAcl,

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ export {
   getDatetimeOne,
   getDecimalOne,
   getIntegerOne,
-  getStringInLocaleOne,
+  getStringWithLocaleOne,
   getStringNoLocaleOne,
   getUrlAll,
   getIriAll,
@@ -56,7 +56,7 @@ export {
   getDatetimeAll,
   getDecimalAll,
   getIntegerAll,
-  getStringInLocaleAll,
+  getStringWithLocaleAll,
   getStringNoLocaleAll,
   getLiteralOne,
   getNamedNodeOne,
@@ -67,6 +67,10 @@ export {
   getStringNoLocaleOne as getStringUnlocalizedOne,
   /** @deprecated See [[getStringNoLocaleAll]] */
   getStringNoLocaleAll as getStringUnlocalizedAll,
+  /** @deprecated See [[getStringWithLocaleOne]] */
+  getStringWithLocaleOne as getStringInLocaleOne,
+  /** @deprecated See [[getStringWithLocaleAll]] */
+  getStringWithLocaleAll as getStringInLocaleAll,
 } from "./thing/get";
 export {
   addUrl,
@@ -75,13 +79,15 @@ export {
   addDatetime,
   addDecimal,
   addInteger,
-  addStringInLocale,
+  addStringWithLocale,
   addStringNoLocale,
   addLiteral,
   addNamedNode,
   // Aliases for deprecated exports to preserve backwards compatibility:
   /** @deprecated See [[addStringNoLocale]] */
   addStringNoLocale as addStringUnlocalized,
+  /** @deprecated See [[addStringWithLocale]] */
+  addStringWithLocale as addStringInLocale,
 } from "./thing/add";
 export {
   setUrl,
@@ -90,13 +96,15 @@ export {
   setDatetime,
   setDecimal,
   setInteger,
-  setStringInLocale,
+  setStringWithLocale,
   setStringNoLocale,
   setLiteral,
   setNamedNode,
   // Aliases for deprecated exports to preserve backwards compatibility:
   /** @deprecated See [[setStringNoLocale]] */
   setStringNoLocale as setStringUnlocalized,
+  /** @deprecated See [[setStringWithLocale]] */
+  setStringWithLocale as setStringInLocale,
 } from "./thing/set";
 export {
   removeAll,
@@ -106,13 +114,15 @@ export {
   removeDatetime,
   removeDecimal,
   removeInteger,
-  removeStringInLocale,
+  removeStringWithLocale,
   removeStringNoLocale,
   removeLiteral,
   removeNamedNode,
   // Aliases for deprecated exports to preserve backwards compatibility:
   /** @deprecated See [[removeStringNoLocale]] */
   removeStringNoLocale as removeStringUnlocalized,
+  /** @deprecated See [[removeStringWithLocale]] */
+  removeStringWithLocale as removeStringInLocale,
 } from "./thing/remove";
 export {
   unstable_hasFallbackAcl,

--- a/src/thing/add.test.ts
+++ b/src/thing/add.test.ts
@@ -30,7 +30,7 @@ import {
   addDatetime,
   addDecimal,
   addInteger,
-  addStringInLocale,
+  addStringWithLocale,
   addStringNoLocale,
   addNamedNode,
   addLiteral,
@@ -859,11 +859,11 @@ describe("addInteger", () => {
   });
 });
 
-describe("addStringInLocale", () => {
+describe("addStringWithLocale", () => {
   it("adds the given localised string value for the given predicate", () => {
     const thing = getMockEmptyThing("https://some.pod/resource#subject");
 
-    const updatedThing = addStringInLocale(
+    const updatedThing = addStringWithLocale(
       thing,
       "https://some.vocab/predicate",
       "Some string",
@@ -884,7 +884,7 @@ describe("addStringInLocale", () => {
   it("accepts Predicates as Named Nodes", () => {
     const thing = getMockEmptyThing("https://some.pod/resource#subject");
 
-    const updatedThing = addStringInLocale(
+    const updatedThing = addStringWithLocale(
       thing,
       DataFactory.namedNode("https://some.vocab/predicate"),
       "Some string",
@@ -905,7 +905,7 @@ describe("addStringInLocale", () => {
   it("does not modify the input Thing", () => {
     const thing = getMockEmptyThing("https://arbitrary.pod/resource#subject");
 
-    const updatedThing = addStringInLocale(
+    const updatedThing = addStringWithLocale(
       thing,
       DataFactory.namedNode("https://arbitrary.vocab/predicate"),
       "Some string",
@@ -922,7 +922,7 @@ describe("addStringInLocale", () => {
       name: "localSubject",
     });
 
-    const updatedThing = addStringInLocale(
+    const updatedThing = addStringWithLocale(
       thingLocal,
       DataFactory.namedNode("https://some.vocab/predicate"),
       "Some string",
@@ -950,7 +950,7 @@ describe("addStringInLocale", () => {
       )
     );
 
-    const updatedThing = addStringInLocale(
+    const updatedThing = addStringWithLocale(
       thing,
       "https://some.vocab/predicate",
       "Some string",
@@ -985,7 +985,7 @@ describe("addStringInLocale", () => {
       )
     );
 
-    const updatedThing = addStringInLocale(
+    const updatedThing = addStringWithLocale(
       thing,
       "https://some.vocab/predicate",
       "Some string",

--- a/src/thing/add.test.ts
+++ b/src/thing/add.test.ts
@@ -31,7 +31,7 @@ import {
   addDecimal,
   addInteger,
   addStringInLocale,
-  addStringUnlocalized,
+  addStringNoLocale,
   addNamedNode,
   addLiteral,
 } from "./add";
@@ -1011,11 +1011,11 @@ describe("addStringInLocale", () => {
   });
 });
 
-describe("addStringUnlocalized", () => {
+describe("addStringNoLocale", () => {
   it("adds the given unlocalised string value for the given predicate", () => {
     const thing = getMockEmptyThing("https://some.pod/resource#subject");
 
-    const updatedThing = addStringUnlocalized(
+    const updatedThing = addStringNoLocale(
       thing,
       "https://some.vocab/predicate",
       "Some string value"
@@ -1035,7 +1035,7 @@ describe("addStringUnlocalized", () => {
   it("accepts Predicates as Named Nodes", () => {
     const thing = getMockEmptyThing("https://some.pod/resource#subject");
 
-    const updatedThing = addStringUnlocalized(
+    const updatedThing = addStringNoLocale(
       thing,
       DataFactory.namedNode("https://some.vocab/predicate"),
       "Some string value"
@@ -1055,7 +1055,7 @@ describe("addStringUnlocalized", () => {
   it("does not modify the input Thing", () => {
     const thing = getMockEmptyThing("https://arbitrary.pod/resource#subject");
 
-    const updatedThing = addStringUnlocalized(
+    const updatedThing = addStringNoLocale(
       thing,
       "https://arbitrary.vocab/predicate",
       "Arbitrary string value"
@@ -1071,7 +1071,7 @@ describe("addStringUnlocalized", () => {
       name: "localSubject",
     });
 
-    const updatedThing = addStringUnlocalized(
+    const updatedThing = addStringNoLocale(
       thingLocal,
       "https://some.vocab/predicate",
       "Some string value"
@@ -1098,7 +1098,7 @@ describe("addStringUnlocalized", () => {
       )
     );
 
-    const updatedThing = addStringUnlocalized(
+    const updatedThing = addStringNoLocale(
       thing,
       "https://some.vocab/predicate",
       "Some string value"
@@ -1132,7 +1132,7 @@ describe("addStringUnlocalized", () => {
       )
     );
 
-    const updatedThing = addStringUnlocalized(
+    const updatedThing = addStringNoLocale(
       thing,
       "https://some.vocab/predicate",
       "Some string value"

--- a/src/thing/add.ts
+++ b/src/thing/add.ts
@@ -153,7 +153,7 @@ export const addInteger: AddOfType<number> = (thing, predicate, value) => {
 /**
  * Create a new Thing with a localised string added for a Predicate.
  *
- * This preserves existing values for the given Predicate. To replace them, see [[setStringInLocale]].
+ * This preserves existing values for the given Predicate. To replace them, see [[setStringWithLocale]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
@@ -163,13 +163,13 @@ export const addInteger: AddOfType<number> = (thing, predicate, value) => {
  * @param locale Locale of the added string.
  * @returns A new Thing equal to the input Thing with the given value added for the given Predicate.
  */
-export function addStringInLocale<T extends Thing>(
+export function addStringWithLocale<T extends Thing>(
   thing: T,
   predicate: Url | UrlString,
   value: string,
   locale: string
 ): T extends ThingLocal ? ThingLocal : ThingPersisted;
-export function addStringInLocale(
+export function addStringWithLocale(
   thing: Thing,
   predicate: Url | UrlString,
   value: string,

--- a/src/thing/add.ts
+++ b/src/thing/add.ts
@@ -182,7 +182,7 @@ export function addStringInLocale(
 /**
  * Create a new Thing with an unlocalised string added for a Predicate.
  *
- * This preserves existing values for the given Predicate. To replace them, see [[setStringUnlocalized]].
+ * This preserves existing values for the given Predicate. To replace them, see [[setStringNoLocale]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
@@ -191,7 +191,7 @@ export function addStringInLocale(
  * @param value String to add to `thing` for the given `predicate`.
  * @returns A new Thing equal to the input Thing with the given value added for the given Predicate.
  */
-export const addStringUnlocalized: AddOfType<string> = (
+export const addStringNoLocale: AddOfType<string> = (
   thing,
   predicate,
   value

--- a/src/thing/get.test.ts
+++ b/src/thing/get.test.ts
@@ -30,7 +30,7 @@ import {
   getDatetimeOne,
   getDecimalOne,
   getIntegerOne,
-  getStringInLocaleOne,
+  getStringWithLocaleOne,
   getStringNoLocaleOne,
   getLiteralOne,
   getNamedNodeOne,
@@ -39,7 +39,7 @@ import {
   getDatetimeAll,
   getDecimalAll,
   getIntegerAll,
-  getStringInLocaleAll,
+  getStringWithLocaleAll,
   getStringNoLocaleAll,
   getLiteralAll,
   getNamedNodeAll,
@@ -971,7 +971,7 @@ describe("getIntegerAll", () => {
   });
 });
 
-describe("getStringInLocaleOne", () => {
+describe("getStringWithLocaleOne", () => {
   it("returns the string value for the given Predicate in the given locale", () => {
     const literalWithLocale = DataFactory.literal("Some value", "nl-NL");
     const quad = DataFactory.quad(
@@ -986,7 +986,7 @@ describe("getStringInLocaleOne", () => {
     });
 
     expect(
-      getStringInLocaleOne(
+      getStringWithLocaleOne(
         thingWithLocaleString,
         "https://some.vocab/predicate",
         "nl-NL"
@@ -1008,7 +1008,7 @@ describe("getStringInLocaleOne", () => {
     });
 
     expect(
-      getStringInLocaleOne(
+      getStringWithLocaleOne(
         thingWithLocaleString,
         DataFactory.namedNode("https://some.vocab/predicate"),
         "nl-NL"
@@ -1030,7 +1030,7 @@ describe("getStringInLocaleOne", () => {
     });
 
     expect(
-      getStringInLocaleOne(
+      getStringWithLocaleOne(
         thingWithLocaleString,
         "https://some.vocab/predicate",
         "NL-nL"
@@ -1046,7 +1046,7 @@ describe("getStringInLocaleOne", () => {
     );
 
     expect(
-      getStringInLocaleOne(
+      getStringWithLocaleOne(
         thingWithoutStringNoLocale,
         "https://some.vocab/predicate",
         "nl-NL"
@@ -1068,14 +1068,14 @@ describe("getStringInLocaleOne", () => {
     });
 
     expect(
-      getStringInLocaleOne(
+      getStringWithLocaleOne(
         thingWithDifferentLocaleString,
         "https://some.vocab/predicate",
         "en-GB"
       )
     ).toBeNull();
     expect(
-      getStringInLocaleOne(
+      getStringWithLocaleOne(
         thingWithDifferentLocaleString,
         "https://some.vocab/predicate",
         "nl"
@@ -1105,7 +1105,7 @@ describe("getStringInLocaleOne", () => {
     );
 
     expect(
-      getStringInLocaleOne(
+      getStringWithLocaleOne(
         thingWithDifferentDatatypes,
         "https://some.vocab/predicate",
         "nl-NL"
@@ -1127,7 +1127,7 @@ describe("getStringInLocaleOne", () => {
     });
 
     expect(
-      getStringInLocaleOne(
+      getStringWithLocaleOne(
         thingWithLocaleString,
         "https://some-other.vocab/predicate",
         "nl-NL"
@@ -1136,7 +1136,7 @@ describe("getStringInLocaleOne", () => {
   });
 });
 
-describe("getStringsInLocaleAll", () => {
+describe("getStringsWithLocaleAll", () => {
   it("returns the string values for the given Predicate in the given locale", () => {
     const literalWithLocale1 = DataFactory.literal("Some value 1", "nl-NL");
     const quad1 = DataFactory.quad(
@@ -1158,7 +1158,7 @@ describe("getStringsInLocaleAll", () => {
     });
 
     expect(
-      getStringInLocaleAll(
+      getStringWithLocaleAll(
         thingWithLocaleStrings,
         "https://some.vocab/predicate",
         "nl-NL"
@@ -1187,7 +1187,7 @@ describe("getStringsInLocaleAll", () => {
     });
 
     expect(
-      getStringInLocaleAll(
+      getStringWithLocaleAll(
         thingWithLocaleStrings,
         DataFactory.namedNode("https://some.vocab/predicate"),
         "nl-NL"
@@ -1209,7 +1209,7 @@ describe("getStringsInLocaleAll", () => {
     });
 
     expect(
-      getStringInLocaleAll(
+      getStringWithLocaleAll(
         thingWithLocaleString,
         "https://some.vocab/predicate",
         "NL-nL"
@@ -1225,7 +1225,7 @@ describe("getStringsInLocaleAll", () => {
     );
 
     expect(
-      getStringInLocaleAll(
+      getStringWithLocaleAll(
         thingWithoutStringNoLocales,
         "https://some.vocab/predicate",
         "nl-NL"
@@ -1247,14 +1247,14 @@ describe("getStringsInLocaleAll", () => {
     });
 
     expect(
-      getStringInLocaleAll(
+      getStringWithLocaleAll(
         thingWithDifferentLocaleStrings,
         "https://some.vocab/predicate",
         "en-GB"
       )
     ).toEqual([]);
     expect(
-      getStringInLocaleAll(
+      getStringWithLocaleAll(
         thingWithDifferentLocaleStrings,
         "https://some.vocab/predicate",
         "nl"
@@ -1284,7 +1284,7 @@ describe("getStringsInLocaleAll", () => {
     );
 
     expect(
-      getStringInLocaleAll(
+      getStringWithLocaleAll(
         thingWithDifferentDatatypes,
         "https://some.vocab/predicate",
         "nl-NL"
@@ -1306,7 +1306,7 @@ describe("getStringsInLocaleAll", () => {
     });
 
     expect(
-      getStringInLocaleAll(
+      getStringWithLocaleAll(
         thingWithLocaleString,
         "https://some-other.vocab/predicate",
         "nl-NL"

--- a/src/thing/get.test.ts
+++ b/src/thing/get.test.ts
@@ -31,7 +31,7 @@ import {
   getDecimalOne,
   getIntegerOne,
   getStringInLocaleOne,
-  getStringUnlocalizedOne,
+  getStringNoLocaleOne,
   getLiteralOne,
   getNamedNodeOne,
   getUrlAll,
@@ -40,7 +40,7 @@ import {
   getDecimalAll,
   getIntegerAll,
   getStringInLocaleAll,
-  getStringUnlocalizedAll,
+  getStringNoLocaleAll,
   getLiteralAll,
   getNamedNodeAll,
 } from "./get";
@@ -1039,7 +1039,7 @@ describe("getStringInLocaleOne", () => {
   });
 
   it("returns null if no locale string value was found", () => {
-    const thingWithoutStringUnlocalized = getMockThingWithLiteralFor(
+    const thingWithoutStringNoLocale = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "42",
       "integer"
@@ -1047,7 +1047,7 @@ describe("getStringInLocaleOne", () => {
 
     expect(
       getStringInLocaleOne(
-        thingWithoutStringUnlocalized,
+        thingWithoutStringNoLocale,
         "https://some.vocab/predicate",
         "nl-NL"
       )
@@ -1218,7 +1218,7 @@ describe("getStringsInLocaleAll", () => {
   });
 
   it("returns an empty array if no locale string values were found", () => {
-    const thingWithoutStringUnlocalizeds = getMockThingWithLiteralFor(
+    const thingWithoutStringNoLocales = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "42",
       "integer"
@@ -1226,7 +1226,7 @@ describe("getStringsInLocaleAll", () => {
 
     expect(
       getStringInLocaleAll(
-        thingWithoutStringUnlocalizeds,
+        thingWithoutStringNoLocales,
         "https://some.vocab/predicate",
         "nl-NL"
       )
@@ -1315,47 +1315,47 @@ describe("getStringsInLocaleAll", () => {
   });
 });
 
-describe("getStringUnlocalizedOne", () => {
+describe("getStringNoLocaleOne", () => {
   it("returns the string value for the given Predicate", () => {
-    const thingWithStringUnlocalized = getMockThingWithLiteralFor(
+    const thingWithStringNoLocale = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "Some value",
       "string"
     );
 
     expect(
-      getStringUnlocalizedOne(
-        thingWithStringUnlocalized,
+      getStringNoLocaleOne(
+        thingWithStringNoLocale,
         "https://some.vocab/predicate"
       )
     ).toBe("Some value");
   });
 
   it("accepts Predicates as Named Nodes", () => {
-    const thingWithStringUnlocalized = getMockThingWithLiteralFor(
+    const thingWithStringNoLocale = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "Some value",
       "string"
     );
 
     expect(
-      getStringUnlocalizedOne(
-        thingWithStringUnlocalized,
+      getStringNoLocaleOne(
+        thingWithStringNoLocale,
         DataFactory.namedNode("https://some.vocab/predicate")
       )
     ).toBe("Some value");
   });
 
   it("returns null if no string value was found", () => {
-    const thingWithoutStringUnlocalized = getMockThingWithLiteralFor(
+    const thingWithoutStringNoLocale = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "42",
       "integer"
     );
 
     expect(
-      getStringUnlocalizedOne(
-        thingWithoutStringUnlocalized,
+      getStringNoLocaleOne(
+        thingWithoutStringNoLocale,
         "https://some.vocab/predicate"
       )
     ).toBeNull();
@@ -1383,7 +1383,7 @@ describe("getStringUnlocalizedOne", () => {
     );
 
     expect(
-      getStringUnlocalizedOne(
+      getStringNoLocaleOne(
         thingWithDifferentDatatypes,
         "https://some.vocab/predicate"
       )
@@ -1391,24 +1391,24 @@ describe("getStringUnlocalizedOne", () => {
   });
 
   it("returns null if no string value was found for the given Predicate", () => {
-    const thingWithStringUnlocalized = getMockThingWithLiteralFor(
+    const thingWithStringNoLocale = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "Arbitrary value",
       "string"
     );
 
     expect(
-      getStringUnlocalizedOne(
-        thingWithStringUnlocalized,
+      getStringNoLocaleOne(
+        thingWithStringNoLocale,
         "https://some-other.vocab/predicate"
       )
     ).toBeNull();
   });
 });
 
-describe("getStringUnlocalizedAll", () => {
+describe("getStringNoLocaleAll", () => {
   it("returns the string values for the given Predicate", () => {
-    const thingWithStringUnlocalizeds = getMockThingWithLiteralsFor(
+    const thingWithStringNoLocales = getMockThingWithLiteralsFor(
       "https://some.vocab/predicate",
       "Some value 1",
       "Some value 2",
@@ -1416,15 +1416,15 @@ describe("getStringUnlocalizedAll", () => {
     );
 
     expect(
-      getStringUnlocalizedAll(
-        thingWithStringUnlocalizeds,
+      getStringNoLocaleAll(
+        thingWithStringNoLocales,
         "https://some.vocab/predicate"
       )
     ).toEqual(["Some value 1", "Some value 2"]);
   });
 
   it("accepts Predicates as Named Nodes", () => {
-    const thingWithStringUnlocalizeds = getMockThingWithLiteralsFor(
+    const thingWithStringNoLocales = getMockThingWithLiteralsFor(
       "https://some.vocab/predicate",
       "Some value 1",
       "Some value 2",
@@ -1432,23 +1432,23 @@ describe("getStringUnlocalizedAll", () => {
     );
 
     expect(
-      getStringUnlocalizedAll(
-        thingWithStringUnlocalizeds,
+      getStringNoLocaleAll(
+        thingWithStringNoLocales,
         DataFactory.namedNode("https://some.vocab/predicate")
       )
     ).toEqual(["Some value 1", "Some value 2"]);
   });
 
   it("returns an empty array if no string values were found", () => {
-    const thingWithoutStringUnlocalizeds = getMockThingWithLiteralFor(
+    const thingWithoutStringNoLocales = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "42",
       "integer"
     );
 
     expect(
-      getStringUnlocalizedAll(
-        thingWithoutStringUnlocalizeds,
+      getStringNoLocaleAll(
+        thingWithoutStringNoLocales,
         "https://some.vocab/predicate"
       )
     ).toEqual([]);
@@ -1476,7 +1476,7 @@ describe("getStringUnlocalizedAll", () => {
     );
 
     expect(
-      getStringUnlocalizedAll(
+      getStringNoLocaleAll(
         thingWithDifferentDatatypes,
         "https://some.vocab/predicate"
       )
@@ -1484,15 +1484,15 @@ describe("getStringUnlocalizedAll", () => {
   });
 
   it("returns an empty array if no string values were found for the given Predicate", () => {
-    const thingWithStringUnlocalized = getMockThingWithLiteralFor(
+    const thingWithStringNoLocale = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "Arbitrary value",
       "string"
     );
 
     expect(
-      getStringUnlocalizedAll(
-        thingWithStringUnlocalized,
+      getStringNoLocaleAll(
+        thingWithStringNoLocale,
         "https://some-other.vocab/predicate"
       )
     ).toEqual([]);

--- a/src/thing/get.ts
+++ b/src/thing/get.ts
@@ -247,7 +247,7 @@ export function getIntegerAll(
  * @param locale The desired locale for the string value.
  * @returns A localised string value for the given Predicate, if present in `locale`, or null otherwise.
  */
-export function getStringInLocaleOne(
+export function getStringWithLocaleOne(
   thing: Thing,
   predicate: Url | UrlString,
   locale: string
@@ -269,7 +269,7 @@ export function getStringInLocaleOne(
  * @param locale The desired locale for the string values.
  * @returns The localised string values for the given Predicate.
  */
-export function getStringInLocaleAll(
+export function getStringWithLocaleAll(
   thing: Thing,
   predicate: Url | UrlString,
   locale: string

--- a/src/thing/get.ts
+++ b/src/thing/get.ts
@@ -286,7 +286,7 @@ export function getStringInLocaleAll(
  * @param predicate The given Predicate for which you want the string value.
  * @returns A string value for the given Predicate, if present, or null otherwise.
  */
-export function getStringUnlocalizedOne(
+export function getStringNoLocaleOne(
   thing: Thing,
   predicate: Url | UrlString
 ): string | null {
@@ -304,7 +304,7 @@ export function getStringUnlocalizedOne(
  * @param predicate The given Predicate for which you want the string values.
  * @returns The string values for the given Predicate.
  */
-export function getStringUnlocalizedAll(
+export function getStringNoLocaleAll(
   thing: Thing,
   predicate: Url | UrlString
 ): string[] {

--- a/src/thing/remove.test.ts
+++ b/src/thing/remove.test.ts
@@ -31,7 +31,7 @@ import {
   removeDatetime,
   removeDecimal,
   removeInteger,
-  removeStringInLocale,
+  removeStringWithLocale,
   removeStringNoLocale,
   removeLiteral,
   removeNamedNode,
@@ -996,8 +996,8 @@ describe("removeInteger", () => {
   });
 });
 
-describe("removeStringInLocale", () => {
-  function getMockQuadWithStringInLocaleFor(
+describe("removeStringWithLocale", () => {
+  function getMockQuadWithStringWithLocaleFor(
     predicate: IriString,
     literalValue: string,
     locale: string
@@ -1009,12 +1009,12 @@ describe("removeStringInLocale", () => {
     );
     return quad;
   }
-  function getMockThingWithStringInLocaleFor(
+  function getMockThingWithStringWithLocaleFor(
     predicate: IriString,
     literalValue: string,
     locale: string
   ): Thing {
-    const quad = getMockQuadWithStringInLocaleFor(
+    const quad = getMockQuadWithStringWithLocaleFor(
       predicate,
       literalValue,
       locale
@@ -1025,14 +1025,14 @@ describe("removeStringInLocale", () => {
     return Object.assign(thing, { url: "https://arbitrary.vocab/subject" });
   }
   it("removes the given localised string for the given Predicate", () => {
-    const thingWithStringInLocale = getMockThingWithStringInLocaleFor(
+    const thingWithStringWithLocale = getMockThingWithStringWithLocaleFor(
       "https://some.vocab/predicate",
       "Une chaîne de caractères quelconque",
       "fr-fr"
     );
 
-    const updatedThing = removeStringInLocale(
-      thingWithStringInLocale,
+    const updatedThing = removeStringWithLocale(
+      thingWithStringWithLocale,
       "https://some.vocab/predicate",
       "Une chaîne de caractères quelconque",
       "fr-fr"
@@ -1042,14 +1042,14 @@ describe("removeStringInLocale", () => {
   });
 
   it("accepts Predicates as Named Nodes", () => {
-    const thingWithStringInLocale = getMockThingWithStringInLocaleFor(
+    const thingWithStringWithLocale = getMockThingWithStringWithLocaleFor(
       "https://some.vocab/predicate",
       "Some arbitrary string",
       "en-us"
     );
 
-    const updatedThing = removeStringInLocale(
-      thingWithStringInLocale,
+    const updatedThing = removeStringWithLocale(
+      thingWithStringWithLocale,
       DataFactory.namedNode("https://some.vocab/predicate"),
       "Some arbitrary string",
       "en-us"
@@ -1059,20 +1059,20 @@ describe("removeStringInLocale", () => {
   });
 
   it("does not modify the input Thing", () => {
-    const thingWithStringInLocale = getMockThingWithStringInLocaleFor(
+    const thingWithStringWithLocale = getMockThingWithStringWithLocaleFor(
       "https://some.vocab/predicate",
       "Some arbitrary string",
       "en-us"
     );
 
-    const updatedThing = removeStringInLocale(
-      thingWithStringInLocale,
+    const updatedThing = removeStringWithLocale(
+      thingWithStringWithLocale,
       "https://some.vocab/predicate",
       "Some arbitrary string",
       "en-us"
     );
 
-    expect(Array.from(thingWithStringInLocale)).toHaveLength(1);
+    expect(Array.from(thingWithStringWithLocale)).toHaveLength(1);
     expect(Array.from(updatedThing)).toHaveLength(0);
   });
 
@@ -1092,7 +1092,7 @@ describe("removeStringInLocale", () => {
       name: "localSubject",
     });
 
-    const updatedThing = removeStringInLocale(
+    const updatedThing = removeStringWithLocale(
       thingLocal,
       "https://some.vocab/predicate",
       "Some arbitrary string",
@@ -1103,17 +1103,17 @@ describe("removeStringInLocale", () => {
   });
 
   it("removes multiple instances of the same localised string for the same Predicate", () => {
-    const thingWithDuplicateStringInLocale = getMockThingWithStringInLocaleFor(
+    const thingWithDuplicateStringWithLocale = getMockThingWithStringWithLocaleFor(
       "https://some.vocab/predicate",
       "Some arbitrary string",
       "en-us"
     );
-    thingWithDuplicateStringInLocale.add(
-      Array.from(thingWithDuplicateStringInLocale)[0]
+    thingWithDuplicateStringWithLocale.add(
+      Array.from(thingWithDuplicateStringWithLocale)[0]
     );
 
-    const updatedThing = removeStringInLocale(
-      thingWithDuplicateStringInLocale,
+    const updatedThing = removeStringWithLocale(
+      thingWithDuplicateStringWithLocale,
       "https://some.vocab/predicate",
       "Some arbitrary string",
       "en-us"
@@ -1123,35 +1123,35 @@ describe("removeStringInLocale", () => {
   });
 
   it("does not remove Quads with different Predicates or Objects", () => {
-    const thingWithStringInLocale = getMockThingWithStringInLocaleFor(
+    const thingWithStringWithLocale = getMockThingWithStringWithLocaleFor(
       "https://some.vocab/predicate",
       "Some arbitrary string",
       "en-us"
     );
 
-    const mockQuadWithDifferentStringInSameLocale = getMockQuadWithStringInLocaleFor(
+    const mockQuadWithDifferentStringInSameLocale = getMockQuadWithStringWithLocaleFor(
       "https://some.vocab/predicate",
       "Some other arbitrary string",
       "en-us"
     );
 
-    const mockQuadWithSameStringInDifferentLocale = getMockQuadWithStringInLocaleFor(
+    const mockQuadWithSameStringInDifferentLocale = getMockQuadWithStringWithLocaleFor(
       "https://some.vocab/predicate",
       "Some arbitrary string",
       "en-uk"
     );
 
-    const mockQuadWithDifferentPredicate = getMockQuadWithStringInLocaleFor(
+    const mockQuadWithDifferentPredicate = getMockQuadWithStringWithLocaleFor(
       "https://some.other.vocab/predicate",
       "Some arbitrary string",
       "en-us"
     );
-    thingWithStringInLocale.add(mockQuadWithDifferentStringInSameLocale);
-    thingWithStringInLocale.add(mockQuadWithSameStringInDifferentLocale);
-    thingWithStringInLocale.add(mockQuadWithDifferentPredicate);
+    thingWithStringWithLocale.add(mockQuadWithDifferentStringInSameLocale);
+    thingWithStringWithLocale.add(mockQuadWithSameStringInDifferentLocale);
+    thingWithStringWithLocale.add(mockQuadWithDifferentPredicate);
 
-    const updatedThing = removeStringInLocale(
-      thingWithStringInLocale,
+    const updatedThing = removeStringWithLocale(
+      thingWithStringWithLocale,
       "https://some.vocab/predicate",
       "Some arbitrary string",
       "en-US"
@@ -1165,22 +1165,22 @@ describe("removeStringInLocale", () => {
   });
 
   it("removes Quads when the locale casing mismatch", () => {
-    const thingWithStringInLocale = getMockThingWithStringInLocaleFor(
+    const thingWithStringWithLocale = getMockThingWithStringWithLocaleFor(
       "https://some.vocab/predicate",
       "Some arbitrary string",
       "en-us"
     );
 
-    const mockQuadWithStringInDifferentLocale = getMockQuadWithStringInLocaleFor(
+    const mockQuadWithStringInDifferentLocale = getMockQuadWithStringWithLocaleFor(
       "https://some.vocab/predicate",
       "Some arbitrary string",
       "en-US"
     );
 
-    thingWithStringInLocale.add(mockQuadWithStringInDifferentLocale);
+    thingWithStringWithLocale.add(mockQuadWithStringInDifferentLocale);
 
-    const updatedThing = removeStringInLocale(
-      thingWithStringInLocale,
+    const updatedThing = removeStringWithLocale(
+      thingWithStringWithLocale,
       "https://some.vocab/predicate",
       "Some arbitrary string",
       "en-US"
@@ -1190,7 +1190,7 @@ describe("removeStringInLocale", () => {
   });
 
   it("does not remove Quads with non-string Objects", () => {
-    const thingWithLocalizedString = getMockThingWithStringInLocaleFor(
+    const thingWithLocalizedString = getMockThingWithStringWithLocaleFor(
       "https://some.vocab/predicate",
       "Some arbitrary string",
       "en-US"
@@ -1202,7 +1202,7 @@ describe("removeStringInLocale", () => {
     );
     thingWithLocalizedString.add(mockQuadWithInteger);
 
-    const updatedThing = removeStringInLocale(
+    const updatedThing = removeStringWithLocale(
       thingWithLocalizedString,
       "https://some.vocab/predicate",
       "Some arbitrary string",
@@ -1392,12 +1392,12 @@ describe("removeLiteral", () => {
     const thing = dataset();
     thing.add(quad);
 
-    const thingWithStringInLocale = Object.assign(thing, {
+    const thingWithStringWithLocale = Object.assign(thing, {
       url: "https://arbitrary.vocab/subject",
     });
 
     const updatedThing = removeLiteral(
-      thingWithStringInLocale,
+      thingWithStringWithLocale,
       "https://some.vocab/predicate",
       DataFactory.literal("Some arbitrary string", "en-US")
     );

--- a/src/thing/remove.test.ts
+++ b/src/thing/remove.test.ts
@@ -32,7 +32,7 @@ import {
   removeDecimal,
   removeInteger,
   removeStringInLocale,
-  removeStringUnlocalized,
+  removeStringNoLocale,
   removeLiteral,
   removeNamedNode,
 } from "./remove";
@@ -1213,16 +1213,16 @@ describe("removeStringInLocale", () => {
   });
 });
 
-describe("removeStringUnlocalized", () => {
+describe("removeStringNoLocale", () => {
   it("removes the given string value for the given Predicate", () => {
-    const thingWithStringUnlocalized = getMockThingWithLiteralFor(
+    const thingWithStringNoLocale = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "Some arbitrary string",
       "string"
     );
 
-    const updatedThing = removeStringUnlocalized(
-      thingWithStringUnlocalized,
+    const updatedThing = removeStringNoLocale(
+      thingWithStringNoLocale,
       "https://some.vocab/predicate",
       "Some arbitrary string"
     );
@@ -1231,14 +1231,14 @@ describe("removeStringUnlocalized", () => {
   });
 
   it("accepts Predicates as Named Nodes", () => {
-    const thingWithStringUnlocalized = getMockThingWithLiteralFor(
+    const thingWithStringNoLocale = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "Some arbitrary string",
       "string"
     );
 
-    const updatedThing = removeStringUnlocalized(
-      thingWithStringUnlocalized,
+    const updatedThing = removeStringNoLocale(
+      thingWithStringNoLocale,
       DataFactory.namedNode("https://some.vocab/predicate"),
       "Some arbitrary string"
     );
@@ -1247,19 +1247,19 @@ describe("removeStringUnlocalized", () => {
   });
 
   it("does not modify the input Thing", () => {
-    const thingWithStringUnlocalized = getMockThingWithLiteralFor(
+    const thingWithStringNoLocale = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "Some arbitrary string",
       "string"
     );
 
-    const updatedThing = removeStringUnlocalized(
-      thingWithStringUnlocalized,
+    const updatedThing = removeStringNoLocale(
+      thingWithStringNoLocale,
       "https://some.vocab/predicate",
       "Some arbitrary string"
     );
 
-    expect(Array.from(thingWithStringUnlocalized)).toHaveLength(1);
+    expect(Array.from(thingWithStringNoLocale)).toHaveLength(1);
     expect(Array.from(updatedThing)).toHaveLength(0);
   });
 
@@ -1282,7 +1282,7 @@ describe("removeStringUnlocalized", () => {
       name: "localSubject",
     });
 
-    const updatedThing = removeStringUnlocalized(
+    const updatedThing = removeStringNoLocale(
       thingLocal,
       "https://some.vocab/predicate",
       "Some arbitrary string"
@@ -1299,7 +1299,7 @@ describe("removeStringUnlocalized", () => {
     );
     thingWithDuplicateString.add(Array.from(thingWithDuplicateString)[0]);
 
-    const updatedThing = removeStringUnlocalized(
+    const updatedThing = removeStringNoLocale(
       thingWithDuplicateString,
       "https://some.vocab/predicate",
       "Some arbitrary string"
@@ -1328,7 +1328,7 @@ describe("removeStringUnlocalized", () => {
     thingWithOtherQuads.add(mockQuadWithDifferentObject);
     thingWithOtherQuads.add(mockQuadWithDifferentPredicate);
 
-    const updatedThing = removeStringUnlocalized(
+    const updatedThing = removeStringNoLocale(
       thingWithOtherQuads,
       "https://some.vocab/predicate",
       "Some arbitrary string"
@@ -1353,7 +1353,7 @@ describe("removeStringUnlocalized", () => {
     );
     thingWithString.add(mockQuadWithInteger);
 
-    const updatedThing = removeStringUnlocalized(
+    const updatedThing = removeStringNoLocale(
       thingWithString,
       "https://some.vocab/predicate",
       "Some arbitrary string"
@@ -1365,14 +1365,14 @@ describe("removeStringUnlocalized", () => {
 
 describe("removeLiteral", () => {
   it("accepts unlocalised strings as Literal", () => {
-    const thingWithStringUnlocalized = getMockThingWithLiteralFor(
+    const thingWithStringNoLocale = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "Some arbitrary string",
       "string"
     );
 
     const updatedThing = removeLiteral(
-      thingWithStringUnlocalized,
+      thingWithStringNoLocale,
       "https://some.vocab/predicate",
       DataFactory.literal(
         "Some arbitrary string",

--- a/src/thing/remove.ts
+++ b/src/thing/remove.ts
@@ -199,13 +199,13 @@ export const removeInteger: RemoveOfType<number> = (
  * @param locale Locale of the string to remove.
  * @returns A new Thing equal to the input Thing with the given value removed for the given Predicate.
  */
-export function removeStringInLocale<T extends Thing>(
+export function removeStringWithLocale<T extends Thing>(
   thing: T,
   predicate: Url | UrlString,
   value: string,
   locale: string
 ): T extends ThingLocal ? ThingLocal : ThingPersisted;
-export function removeStringInLocale(
+export function removeStringWithLocale(
   thing: Thing,
   predicate: Url | UrlString,
   value: string,

--- a/src/thing/remove.ts
+++ b/src/thing/remove.ts
@@ -231,7 +231,7 @@ export function removeStringInLocale(
  * @param value String to remove from `thing` for the given `predicate`.
  * @returns A new Thing equal to the input Thing with the given value removed for the given Predicate.
  */
-export const removeStringUnlocalized: RemoveOfType<string> = (
+export const removeStringNoLocale: RemoveOfType<string> = (
   thing,
   predicate,
   value

--- a/src/thing/set.test.ts
+++ b/src/thing/set.test.ts
@@ -30,7 +30,7 @@ import {
   setDatetime,
   setDecimal,
   setInteger,
-  setStringInLocale,
+  setStringWithLocale,
   setStringNoLocale,
   setNamedNode,
   setLiteral,
@@ -840,7 +840,7 @@ describe("setInteger", () => {
   });
 });
 
-describe("setStringInLocale", () => {
+describe("setStringWithLocale", () => {
   it("replaces existing values with the given localised string for the given Predicate", () => {
     const existingQuad1 = getMockQuad(
       "https://some.pod/resource#subject",
@@ -855,7 +855,7 @@ describe("setStringInLocale", () => {
     const thing = getMockThing(existingQuad1);
     thing.add(existingQuad2);
 
-    const updatedThing = setStringInLocale(
+    const updatedThing = setStringWithLocale(
       thing,
       "https://some.vocab/predicate",
       "Some string value",
@@ -881,7 +881,7 @@ describe("setStringInLocale", () => {
     );
     const thing = getMockThing(existingQuad);
 
-    const updatedThing = setStringInLocale(
+    const updatedThing = setStringWithLocale(
       thing,
       DataFactory.namedNode("https://some.vocab/predicate"),
       "Some string value",
@@ -906,7 +906,7 @@ describe("setStringInLocale", () => {
     );
     const thing = getMockThing(existingQuad);
 
-    setStringInLocale(
+    setStringWithLocale(
       thing,
       DataFactory.namedNode("https://some.vocab/predicate"),
       "Some string value",
@@ -933,7 +933,7 @@ describe("setStringInLocale", () => {
       name: "localSubject",
     });
 
-    const updatedThing = setStringInLocale(
+    const updatedThing = setStringWithLocale(
       thingLocal,
       "https://some.vocab/predicate",
       "Some string value",
@@ -958,7 +958,7 @@ describe("setStringInLocale", () => {
     );
     const thing = getMockThing(existingQuad);
 
-    const updatedThing = setStringInLocale(
+    const updatedThing = setStringWithLocale(
       thing,
       "https://some.vocab/other-predicate",
       "Some string value",

--- a/src/thing/set.test.ts
+++ b/src/thing/set.test.ts
@@ -31,7 +31,7 @@ import {
   setDecimal,
   setInteger,
   setStringInLocale,
-  setStringUnlocalized,
+  setStringNoLocale,
   setNamedNode,
   setLiteral,
 } from "./set";
@@ -983,7 +983,7 @@ describe("setStringInLocale", () => {
   });
 });
 
-describe("setStringUnlocalized", () => {
+describe("setStringNoLocale", () => {
   it("replaces existing values with the given unlocalised string for the given Predicate", () => {
     const existingQuad1 = getMockQuad(
       "https://some.pod/resource#subject",
@@ -998,7 +998,7 @@ describe("setStringUnlocalized", () => {
     const thing = getMockThing(existingQuad1);
     thing.add(existingQuad2);
 
-    const updatedThing = setStringUnlocalized(
+    const updatedThing = setStringNoLocale(
       thing,
       "https://some.vocab/predicate",
       "Some string value"
@@ -1023,7 +1023,7 @@ describe("setStringUnlocalized", () => {
     );
     const thing = getMockThing(existingQuad);
 
-    const updatedThing = setStringUnlocalized(
+    const updatedThing = setStringNoLocale(
       thing,
       DataFactory.namedNode("https://some.vocab/predicate"),
       "Some string value"
@@ -1047,7 +1047,7 @@ describe("setStringUnlocalized", () => {
     );
     const thing = getMockThing(existingQuad);
 
-    setStringUnlocalized(
+    setStringNoLocale(
       thing,
       DataFactory.namedNode("https://some.vocab/predicate"),
       "Some string value"
@@ -1073,7 +1073,7 @@ describe("setStringUnlocalized", () => {
       name: "localSubject",
     });
 
-    const updatedThing = setStringUnlocalized(
+    const updatedThing = setStringNoLocale(
       thingLocal,
       "https://some.vocab/predicate",
       "Some string value"
@@ -1097,7 +1097,7 @@ describe("setStringUnlocalized", () => {
     );
     const thing = getMockThing(existingQuad);
 
-    const updatedThing = setStringUnlocalized(
+    const updatedThing = setStringNoLocale(
       thing,
       "https://some.vocab/other-predicate",
       "Some string value"

--- a/src/thing/set.ts
+++ b/src/thing/set.ts
@@ -155,7 +155,7 @@ export const setInteger: SetOfType<number> = (thing, predicate, value) => {
 /**
  * Create a new Thing with existing values replaced by the given localised string for the given Predicate.
  *
- * To preserve existing values, see [[addStringInLocale]].
+ * To preserve existing values, see [[addStringWithLocale]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
@@ -165,13 +165,13 @@ export const setInteger: SetOfType<number> = (thing, predicate, value) => {
  * @param locale Locale of the added string.
  * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Predicate.
  */
-export function setStringInLocale<T extends Thing>(
+export function setStringWithLocale<T extends Thing>(
   thing: T,
   predicate: Url | UrlString,
   value: string,
   locale: string
 ): T extends ThingLocal ? ThingLocal : ThingPersisted;
-export function setStringInLocale(
+export function setStringWithLocale(
   thing: Thing,
   predicate: Url | UrlString,
   value: string,

--- a/src/thing/set.ts
+++ b/src/thing/set.ts
@@ -184,7 +184,7 @@ export function setStringInLocale(
 /**
  * Create a new Thing with existing values replaced by the given unlocalised string for the given Predicate.
  *
- * To preserve existing values, see [[addStringUnlocalized]].
+ * To preserve existing values, see [[addStringNoLocale]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
@@ -193,7 +193,7 @@ export function setStringInLocale(
  * @param value Unlocalised string to set on `thing` for the given `predicate`.
  * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Predicate.
  */
-export const setStringUnlocalized: SetOfType<string> = (
+export const setStringNoLocale: SetOfType<string> = (
   thing,
   predicate,
   value

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -37,14 +37,14 @@ const profileResource = await fetchLitDataset(
 ### Reading data
 
 ```typescript
-import { getThingOne, getStringUnlocalisedOne } from "@solid/lit-pod";
+import { getThingOne, getStringNoLocaleOne } from "@solid/lit-pod";
 import { foaf } from "rdf-namespaces";
 
 const profile = getThingOne(
   profileResource,
   "https://vincentt.inrupt.net/profile/card#me"
 );
-const name = getStringUnlocalisedOne(profileResource, foaf.name);
+const name = getStringNoLocaleOne(profileResource, foaf.name);
 ```
 
 For more details, see [Working with Data](./tutorials/working-with-data#reading-data).

--- a/website/docs/tutorials/working-with-data.md
+++ b/website/docs/tutorials/working-with-data.md
@@ -107,8 +107,8 @@ For example:
 
 ```typescript
 import {
-  getStringUnlocalizedAll,
-  getStringUnlocalizedOne,
+  getStringNoLocaleAll,
+  getStringNoLocaleOne,
   getUrlAll,
 } from "@solid/lit-pod";
 
@@ -116,14 +116,14 @@ import {
 // …stating the Thing's name (`http://xmlns.com/foaf/0.1/name`)
 // …of type string
 // …and we expect multiple values:
-const names = getStringUnlocalizedAll(thing, "http://xmlns.com/foaf/0.1/name");
+const names = getStringNoLocaleAll(thing, "http://xmlns.com/foaf/0.1/name");
 // => an array of strings representing the `http://xmlns.com/foaf/0.1/name`.
 
 // We're looking for data…
 // …stating the Thing's Skype ID (`http://xmlns.com/foaf/0.1/skypeId`)
 // …of type string
 // …and we want just one value, assuming it to be the only one:
-const skypeId = getStringUnlocalizedOne(
+const skypeId = getStringNoLocaleOne(
   thing,
   "http://xmlns.com/foaf/0.1/skypeId"
 );
@@ -149,7 +149,7 @@ Putting it all together, here's an example of fetching the nickname of someone w
 import {
   fetchLitDataset,
   getThingOne,
-  getStringUnlocalizedOne,
+  getStringNoLocaleOne,
 } from "@solid/lit-pod";
 
 const profileResource = await fetchLitDataset(
@@ -161,7 +161,7 @@ const profile = getThingOne(
   "https://vincentt.inrupt.net/profile/card#me"
 );
 
-const nickName = getStringUnlocalizedOne(
+const nickName = getStringNoLocaleOne(
   profile,
   "http://xmlns.com/foaf/0.1/nick"
 );
@@ -198,9 +198,9 @@ Let's say we're trying to add a nickname, a characteristic identified by `http:/
 It will be a string (`"timbl"`), and will be in addition to any existing nicknames already listed in `thing`:
 
 ```typescript
-import { addStringUnlocalized } from "@solid/lit-pod";
+import { addStringNoLocale } from "@solid/lit-pod";
 
-let updatedThing = addStringUnlocalized(
+let updatedThing = addStringNoLocale(
   thing,
   `http://xmlns.com/foaf/0.1/nick`,
   "timbl"
@@ -263,7 +263,7 @@ and saving it back:
 import {
   fetchLitDataset,
   getThingOne,
-  setStringUnlocalizedOne,
+  setStringNoLocaleOne,
   setThing,
   saveLitDatasetAt,
 } from "@solid/lit-pod";
@@ -277,7 +277,7 @@ const profile = getThingOne(
   "https://vincentt.inrupt.net/profile/card#me"
 );
 
-const updatedProfile = setStringUnlocalizedOne(
+const updatedProfile = setStringNoLocaleOne(
   profile,
   "http://xmlns.com/foaf/0.1/nick",
   "Your humble tutorial writer"


### PR DESCRIPTION
<!-- When fixing a bug: -->

This PR fixes #137. It renames `StringUnlocalized` to `StringNoLocale`, and `StringInLocale` to `StringWithLocale`. The previous names remain available to avoid forcing Pod Manager to make lots of changes, but they're not documented.

- [x] I've added a unit test to test for potential regressions of this bug. (They're the lame ones that were required by Jest, but :shrug: )
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
