### PR TITLE
Add a refactoring request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/refactoring_request.md
+++ b/.github/ISSUE_TEMPLATE/refactoring_request.md
@@ -1,0 +1,27 @@
+---
+name: Refactoring request
+about: Suggest an architecture change for the code base
+title: ""
+labels: "refactoring"
+assignees: ""
+---
+
+**Search terms you've used**
+
+<!-- What search terms have you used to check whether this refactoring has been requested before? -->
+
+**Is your refactoring request related to a problem? Please describe.**
+
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the solution you'd like**
+
+<!-- A clear and concise description of what you want to happen. -->
+
+**Describe alternatives you've considered**
+
+<!-- A clear and concise description of any alternative solutions or designs you've considered. -->
+
+**Additional context**
+
+<!-- Add any other context or screenshots about the feature request here. -->


### PR DESCRIPTION
This adds an issue template I expect will mostly be used internally, but is a good to keep track of minor refactoring suggestions coming to mind when implementing a feature.

An example issue using this template would be #161. 

- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
