### PR TITLE
Also run Dependabot for the website tooling

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # Enable version updates for library itself
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"
+      ignore:
+        # Prettier introduces style changes in patch releases,
+        # (see https://prettier.io/docs/en/install.html)
+        # so to avoid regular and unpredictable breakage:
+        - dependency-name: "prettier"
+  # Enable version updates for the website tooling
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/website"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Additionally, by driving Dependabot from the repo config, it more
easily carries over when we move repositories, and it's clearer where
to look to change Dependabot settings.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
