### PR TITLE
Only check licences in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       # Prettier for some reason reports that the formatting is off on Windows.
       # Since a single check is sufficient for code formatting, we skip it there:
       if: runner.os != 'Windows'
+    - run: npm run check-licenses
     - name: Archive code coverage results
       uses: actions/upload-artifact@v1.0.0
       with:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "license": "MIT",
   "scripts": {
-    "test": "eslint --config .eslintrc.js \"src/**\" && jest && npm run check-licenses",
+    "test": "eslint --config .eslintrc.js \"src/**\" && jest",
     "e2e-test": "jest --config=jest.e2e.config.js",
     "build": "rollup --config rollup.config.js",
     "prepublishOnly": "yarn run build",


### PR DESCRIPTION
The licences change infrequently, so I think it's best not to interrupt the
development process with a slow check that produces the same results
most of the time when all we need to do is make sure licences we
don't want do not make it into our dependencies before we release.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
