### PR TITLE
Fix dependabot config indentation for `ignore`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,11 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
-      ignore:
-        # Prettier introduces style changes in patch releases,
-        # (see https://prettier.io/docs/en/install.html)
-        # so to avoid regular and unpredictable breakage:
-        - dependency-name: "prettier"
+    ignore:
+      # Prettier introduces style changes in patch releases,
+      # (see https://prettier.io/docs/en/install.html)
+      # so to avoid regular and unpredictable breakage:
+      - dependency-name: "prettier"
   # Enable version updates for the website tooling
   - package-ecosystem: "npm"
     # Look for `package.json` and `lock` files in the `root` directory


### PR DESCRIPTION
<!-- When fixing a bug: -->

Yay for significant whitespace, and yay for not being able to test the working config before merging it :P

Anyway, `ignore` is not a property of `schedule`, but of one package's config directly...

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
