### PR TITLE
Attach the full LocalNode to a ThingLocal

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -46,7 +46,8 @@ export type LitDataset = DatasetCore;
  * A Thing represents all Quads with a given Subject URL and a given Named
  * Graph, from a single Resource.
  */
-export type Thing = DatasetCore & ({ url: UrlString } | { name: string });
+export type Thing = DatasetCore &
+  ({ url: UrlString } | { localSubject: LocalNode });
 /**
  * A [[Thing]] for which we know what the full Subject URL is.
  */
@@ -54,7 +55,7 @@ export type ThingPersisted = Thing & { url: UrlString };
 /**
  * A [[Thing]] whose full Subject URL will be determined when it is persisted.
  */
-export type ThingLocal = Thing & { name: string };
+export type ThingLocal = Thing & { localSubject: LocalNode };
 /**
  * Represents the BlankNode that will be initialised to a NamedNode when persisted.
  *

--- a/src/thing.test.ts
+++ b/src/thing.test.ts
@@ -30,6 +30,7 @@ import {
   removeThing,
   createThing,
   asUrl,
+  toNode,
 } from "./thing";
 import {
   IriString,
@@ -39,6 +40,7 @@ import {
   LitDataset,
   WithResourceInfo,
   WithChangeLog,
+  LocalNode,
 } from "./interfaces";
 
 function getMockQuad(
@@ -69,15 +71,15 @@ describe("createThing", () => {
     const thing1: ThingLocal = createThing();
     const thing2: ThingLocal = createThing();
 
-    expect(typeof thing1.name).toBe("string");
-    expect(thing1.name.length).toBeGreaterThan(0);
-    expect(thing1.name).not.toEqual(thing2.name);
+    expect(typeof thing1.localSubject.name).toBe("string");
+    expect(thing1.localSubject.name.length).toBeGreaterThan(0);
+    expect(thing1.localSubject.name).not.toEqual(thing2.localSubject.name);
   });
 
   it("uses the given name, if any", () => {
     const thing: ThingLocal = createThing({ name: "some-name" });
 
-    expect(thing.name).toBe("some-name");
+    expect(thing.localSubject.name).toBe("some-name");
   });
 
   it("uses the given IRI, if any", () => {
@@ -563,7 +565,9 @@ describe("setThing", () => {
       mockPredicate,
       DataFactory.namedNode("https://some.vocab/new-object")
     );
-    const newThing: Thing = Object.assign(dataset(), { name: "localSubject" });
+    const newThing: Thing = Object.assign(dataset(), {
+      localSubject: localSubject,
+    });
     newThing.add(newThingQuad);
 
     const updatedDataset = setThing(datasetWithLocalSubject, newThing);
@@ -596,7 +600,9 @@ describe("setThing", () => {
       mockPredicate,
       DataFactory.namedNode("https://some.vocab/new-object")
     );
-    const newThing: Thing = Object.assign(dataset(), { name: "subject" });
+    const newThing: Thing = Object.assign(dataset(), {
+      localSubject: localSubject,
+    });
     newThing.add(newThingQuad);
 
     const updatedDataset = setThing(datasetWithNamedNode, newThing);
@@ -627,7 +633,9 @@ describe("setThing", () => {
       subject: "https://some.pod/resource#subject",
       object: "https://some.vocab/old-object",
     });
-    const newThing: Thing = Object.assign(dataset(), { name: "subject" });
+    const newThing: Thing = Object.assign(dataset(), {
+      localSubject: localSubject,
+    });
     newThing.add(newThingQuad);
 
     const updatedDataset = setThing(datasetWithLocalSubject, newThing);
@@ -660,7 +668,9 @@ describe("setThing", () => {
       mockPredicate,
       DataFactory.namedNode("https://some.vocab/new-object")
     );
-    const newThing: Thing = Object.assign(dataset(), { name: "localSubject" });
+    const newThing: Thing = Object.assign(dataset(), {
+      localSubject: localSubject,
+    });
     newThing.add(newThingQuad);
 
     const updatedDataset = setThing(datasetWithLocalSubject, newThing);
@@ -958,7 +968,10 @@ describe("asIri", () => {
   });
 
   it("returns the IRI of a local Thing relative to a given base IRI", () => {
-    const localThing = Object.assign(dataset(), { name: "some-name" });
+    const localSubject: LocalNode = Object.assign(DataFactory.blankNode(), {
+      name: "some-name",
+    });
+    const localThing = Object.assign(dataset(), { localSubject: localSubject });
 
     expect(asUrl(localThing, "https://some.pod/resource")).toBe(
       "https://some.pod/resource#some-name"
@@ -966,10 +979,28 @@ describe("asIri", () => {
   });
 
   it("throws an error when a local Thing was given without a base IRI", () => {
-    const localThing = Object.assign(dataset(), { name: "some-name" });
+    const localSubject: LocalNode = Object.assign(DataFactory.blankNode(), {
+      name: "some-name",
+    });
+    const localThing = Object.assign(dataset(), { localSubject: localSubject });
 
     expect(() => asUrl(localThing, undefined as any)).toThrow(
       "The URL of a Thing that has not been persisted cannot be determined without a base URL."
     );
+  });
+});
+
+describe("toNode", () => {
+  it("should result in equal LocalNodes for the same ThingLocal", () => {
+    const localSubject: LocalNode = Object.assign(
+      DataFactory.blankNode("Arbitrary blank node"),
+      { name: "localSubject" }
+    );
+    const thing: ThingLocal = Object.assign(dataset(), {
+      localSubject: localSubject,
+    });
+    const node1 = toNode(thing);
+    const node2 = toNode(thing);
+    expect(node1.equals(node2)).toBe(true);
   });
 });

--- a/src/thing.ts
+++ b/src/thing.ts
@@ -76,7 +76,7 @@ export function getThingOne(
 
   if (isLocalNode(subject)) {
     const thing: ThingLocal = Object.assign(thingDataset, {
-      name: subject.name,
+      localSubject: subject,
     });
 
     return thing;
@@ -247,7 +247,10 @@ export function createThing(options: CreateThingOptions = {}): Thing {
     return thing;
   }
   const name = (options as CreateThingLocalOptions).name ?? generateName();
-  const thing: ThingLocal = Object.assign(dataset(), { name: name });
+  const localSubject: LocalNode = getLocalNode(name);
+  const thing: ThingLocal = Object.assign(dataset(), {
+    localSubject: localSubject,
+  });
   return thing;
 }
 
@@ -266,7 +269,7 @@ export function asUrl(thing: Thing, baseUrl?: UrlString): UrlString {
         "The URL of a Thing that has not been persisted cannot be determined without a base URL."
       );
     }
-    return resolveLocalIri(thing.name, baseUrl);
+    return resolveLocalIri(thing.localSubject.name, baseUrl);
   }
 
   return thing.url;
@@ -282,7 +285,7 @@ export function isThingLocal(
   thing: ThingPersisted | ThingLocal
 ): thing is ThingLocal {
   return (
-    typeof (thing as ThingLocal).name === "string" &&
+    typeof (thing as ThingLocal).localSubject?.name === "string" &&
     typeof (thing as ThingPersisted).url === "undefined"
   );
 }
@@ -301,7 +304,7 @@ export function toNode(
     return asNamedNode(thing);
   }
   if (isThingLocal(thing)) {
-    return getLocalNode(thing.name);
+    return thing.localSubject;
   }
   return asNamedNode(asUrl(thing));
 }
@@ -317,7 +320,7 @@ export function cloneThing<T extends Thing>(
 export function cloneThing(thing: Thing): Thing {
   const cloned = clone(thing);
   if (isThingLocal(thing)) {
-    (cloned as ThingLocal).name = thing.name;
+    (cloned as ThingLocal).localSubject = thing.localSubject;
     return cloned as ThingLocal;
   }
   (cloned as ThingPersisted).url = thing.url;
@@ -340,7 +343,7 @@ export function filterThing(
 ): Thing {
   const filtered = filter(thing, callback);
   if (isThingLocal(thing)) {
-    (filtered as ThingLocal).name = thing.name;
+    (filtered as ThingLocal).localSubject = thing.localSubject;
     return filtered as ThingLocal;
   }
   (filtered as ThingPersisted).url = thing.url;

--- a/src/thing/add.test.ts
+++ b/src/thing/add.test.ts
@@ -138,9 +138,13 @@ describe("addIri", () => {
 
   it("accepts values as ThingLocals", () => {
     const thing = getMockEmptyThing("https://some.pod/resource#subject");
+    const localSubject: LocalNode = Object.assign(
+      DataFactory.blankNode("Arbitrary blank node"),
+      { name: "localObject" }
+    );
     const datasetWithThingLocal = dataset();
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localObject",
+      localSubject: localSubject,
     });
 
     const updatedThing = addUrl(
@@ -194,9 +198,13 @@ describe("addIri", () => {
   });
 
   it("also works on ThingLocals", () => {
+    const localSubject: LocalNode = Object.assign(
+      DataFactory.blankNode("Arbitrary blank node"),
+      { name: "localSubject" }
+    );
     const datasetWithThingLocal = dataset();
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = addUrl(
@@ -342,9 +350,13 @@ describe("addBoolean", () => {
   });
 
   it("also works on ThingLocals", () => {
+    const localSubject: LocalNode = Object.assign(
+      DataFactory.blankNode("Arbitrary blank node"),
+      { name: "localSubject" }
+    );
     const datasetWithThingLocal = dataset();
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = addBoolean(
@@ -488,9 +500,13 @@ describe("addDatetime", () => {
   });
 
   it("also works on ThingLocals", () => {
+    const localSubject: LocalNode = Object.assign(
+      DataFactory.blankNode("Arbitrary blank node"),
+      { name: "localSubject" }
+    );
     const datasetWithThingLocal = dataset();
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = addDatetime(
@@ -634,9 +650,13 @@ describe("addDecimal", () => {
   });
 
   it("also works on ThingLocals", () => {
+    const localSubject: LocalNode = Object.assign(
+      DataFactory.blankNode("Arbitrary blank node"),
+      { name: "localSubject" }
+    );
     const datasetWithThingLocal = dataset();
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = addDecimal(
@@ -776,9 +796,13 @@ describe("addInteger", () => {
   });
 
   it("also works on ThingLocals", () => {
+    const localSubject: LocalNode = Object.assign(
+      DataFactory.blankNode("Arbitrary blank node"),
+      { name: "localSubject" }
+    );
     const datasetWithThingLocal = dataset();
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = addInteger(
@@ -917,9 +941,13 @@ describe("addStringWithLocale", () => {
   });
 
   it("also works on ThingLocals", () => {
+    const localSubject: LocalNode = Object.assign(
+      DataFactory.blankNode("Arbitrary blank node"),
+      { name: "localSubject" }
+    );
     const datasetWithThingLocal = dataset();
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = addStringWithLocale(
@@ -1066,9 +1094,13 @@ describe("addStringNoLocale", () => {
   });
 
   it("also works on ThingLocals", () => {
+    const localSubject: LocalNode = Object.assign(
+      DataFactory.blankNode("Arbitrary blank node"),
+      { name: "localSubject" }
+    );
     const datasetWithThingLocal = dataset();
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = addStringNoLocale(
@@ -1212,9 +1244,13 @@ describe("addNamedNode", () => {
   });
 
   it("also works on ThingLocals", () => {
+    const localSubject: LocalNode = Object.assign(
+      DataFactory.blankNode("Arbitrary blank node"),
+      { name: "localSubject" }
+    );
     const datasetWithThingLocal = dataset();
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = addNamedNode(
@@ -1361,8 +1397,12 @@ describe("addLiteral", () => {
 
   it("also works on ThingLocals", () => {
     const datasetWithThingLocal = dataset();
+    const localSubject: LocalNode = Object.assign(
+      DataFactory.blankNode("Arbitrary blank node"),
+      { name: "localSubject" }
+    );
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = addLiteral(

--- a/src/thing/remove.test.ts
+++ b/src/thing/remove.test.ts
@@ -153,7 +153,7 @@ describe("removeAll", () => {
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = removeAll(thingLocal, "https://some.vocab/predicate");
@@ -288,7 +288,7 @@ describe("removeIri", () => {
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = removeUrl(
@@ -459,7 +459,7 @@ describe("removeBoolean", () => {
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = removeBoolean(
@@ -609,7 +609,7 @@ describe("removeDatetime", () => {
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = removeDatetime(
@@ -762,7 +762,7 @@ describe("removeDecimal", () => {
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = removeDecimal(
@@ -912,7 +912,7 @@ describe("removeInteger", () => {
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = removeInteger(
@@ -1089,7 +1089,7 @@ describe("removeStringWithLocale", () => {
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = removeStringWithLocale(
@@ -1279,7 +1279,7 @@ describe("removeStringNoLocale", () => {
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = removeStringNoLocale(
@@ -1536,7 +1536,7 @@ describe("removeLiteral", () => {
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = removeLiteral(
@@ -1692,7 +1692,7 @@ describe("removeNamedNode", () => {
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = removeNamedNode(

--- a/src/thing/set.test.ts
+++ b/src/thing/set.test.ts
@@ -175,8 +175,11 @@ describe("setIri", () => {
     );
     const thing = getMockThing(existingQuad);
     const datasetWithThingLocal = dataset();
-    const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
+    const localSubject: LocalNode = Object.assign(DataFactory.blankNode(), {
       name: "localObject",
+    });
+    const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
+      localSubject: localSubject,
     });
 
     const updatedThing = setUrl(
@@ -239,8 +242,11 @@ describe("setIri", () => {
 
   it("also works on ThingLocals", () => {
     const datasetWithThingLocal = dataset();
-    const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
+    const localSubject: LocalNode = Object.assign(DataFactory.blankNode(), {
       name: "localSubject",
+    });
+    const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
+      localSubject: localSubject,
     });
 
     const updatedThing = setUrl(
@@ -379,7 +385,7 @@ describe("setBoolean", () => {
       )
     );
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = setBoolean(
@@ -395,7 +401,7 @@ describe("setBoolean", () => {
         object: literalOfType("boolean", "1"),
       })
     ).toBe(true);
-    expect(updatedThing.name).toBe("localSubject");
+    expect(updatedThing.localSubject.name).toBe("localSubject");
   });
 
   it("preserves existing Quads with different Predicates", () => {
@@ -517,7 +523,7 @@ describe("setDatetime", () => {
       )
     );
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = setDatetime(
@@ -533,7 +539,7 @@ describe("setDatetime", () => {
         object: literalOfType("dateTime", "1990-11-12T13:37:42Z"),
       })
     ).toBe(true);
-    expect(updatedThing.name).toBe("localSubject");
+    expect(updatedThing.localSubject.name).toBe("localSubject");
   });
 
   it("preserves existing Quads with different Predicates", () => {
@@ -655,7 +661,7 @@ describe("setDecimal", () => {
       )
     );
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = setDecimal(
@@ -671,7 +677,7 @@ describe("setDecimal", () => {
         object: literalOfType("decimal", "13.37"),
       })
     ).toBe(true);
-    expect(updatedThing.name).toBe("localSubject");
+    expect(updatedThing.localSubject.name).toBe("localSubject");
   });
 
   it("preserves existing Quads with different Predicates", () => {
@@ -789,7 +795,7 @@ describe("setInteger", () => {
       )
     );
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = setInteger(
@@ -805,7 +811,7 @@ describe("setInteger", () => {
         object: literalOfType("integer", "42"),
       })
     ).toBe(true);
-    expect(updatedThing.name).toBe("localSubject");
+    expect(updatedThing.localSubject.name).toBe("localSubject");
   });
 
   it("preserves existing Quads with different Predicates", () => {
@@ -930,7 +936,7 @@ describe("setStringWithLocale", () => {
       )
     );
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = setStringWithLocale(
@@ -947,7 +953,7 @@ describe("setStringWithLocale", () => {
         object: DataFactory.literal("Some string value", "en-gb"),
       })
     ).toBe(true);
-    expect(updatedThing.name).toBe("localSubject");
+    expect(updatedThing.localSubject.name).toBe("localSubject");
   });
 
   it("preserves existing Quads with different Predicates", () => {
@@ -1070,7 +1076,7 @@ describe("setStringNoLocale", () => {
       )
     );
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = setStringNoLocale(
@@ -1086,7 +1092,7 @@ describe("setStringNoLocale", () => {
         object: literalOfType("string", "Some string value"),
       })
     ).toBe(true);
-    expect(updatedThing.name).toBe("localSubject");
+    expect(updatedThing.localSubject.name).toBe("localSubject");
   });
 
   it("preserves existing Quads with different Predicates", () => {
@@ -1196,8 +1202,12 @@ describe("setNamedNode", () => {
 
   it("also works on ThingLocals", () => {
     const datasetWithThingLocal = dataset();
+    const localSubject = Object.assign(
+      DataFactory.blankNode("Arbitrary blank node"),
+      { name: "localSubject" }
+    );
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = setNamedNode(
@@ -1335,7 +1345,7 @@ describe("setLiteral", () => {
       )
     );
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      name: "localSubject",
+      localSubject: localSubject,
     });
 
     const updatedThing = setLiteral(
@@ -1351,7 +1361,7 @@ describe("setLiteral", () => {
         object: DataFactory.literal("Some string value"),
       })
     ).toBe(true);
-    expect(updatedThing.name).toBe("localSubject");
+    expect(updatedThing.localSubject.name).toBe("localSubject");
   });
 
   it("preserves existing Quads with different Predicates", () => {


### PR DESCRIPTION
<!-- When fixing a bug: -->

We previously attached just the `LocalNode`'s name, but that didn't
work for `getThingOne()` and `getThingAll()`: they would create a new
`LocalNode` and then try to match Quads from a Dataset on that
Subject, but because that new `LocalNode` was, in effect, a new
`BlankNode`, the relevant Quads did not match.

So the change here is that a `ThingLocal` now has a `localSubject` property attached to it, rather than just its `name` (where a `ThingPersisted` has its `iri`): an actual `BlankNode` instance that we can match on, with a `name` attached.

- [x] I've added a unit test to test for potential regressions of this bug: https://github.com/inrupt/lit-pod/pull/190/files#diff-1edc6ef23599ac668f6c25e183a097b2R993-R1007
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
