### PR TITLE
Write agent-specific ACL rules to a given ACL LitDataset

### DIFF
--- a/src/acl.ts
+++ b/src/acl.ts
@@ -293,19 +293,25 @@ export function internal_getAccessModes(
   rule: unstable_AclRule
 ): unstable_AccessModes {
   const ruleAccessModes = getIriAll(rule, acl.mode);
-  const writeAccess = ruleAccessModes.includes(accessModeIriStrings.write);
+  const writeAccess = ruleAccessModes.includes(
+    internal_accessModeIriStrings.write
+  );
   return writeAccess
     ? {
-        read: ruleAccessModes.includes(accessModeIriStrings.read),
+        read: ruleAccessModes.includes(internal_accessModeIriStrings.read),
         append: true,
         write: true,
-        control: ruleAccessModes.includes(accessModeIriStrings.control),
+        control: ruleAccessModes.includes(
+          internal_accessModeIriStrings.control
+        ),
       }
     : {
-        read: ruleAccessModes.includes(accessModeIriStrings.read),
-        append: ruleAccessModes.includes(accessModeIriStrings.append),
+        read: ruleAccessModes.includes(internal_accessModeIriStrings.read),
+        append: ruleAccessModes.includes(internal_accessModeIriStrings.append),
         write: false,
-        control: ruleAccessModes.includes(accessModeIriStrings.control),
+        control: ruleAccessModes.includes(
+          internal_accessModeIriStrings.control
+        ),
       };
 }
 
@@ -396,7 +402,7 @@ function isAclQuad(quad: Quad): boolean {
   }
   if (
     predicate.equals(DataFactory.namedNode(acl.mode)) &&
-    Object.values(accessModeIriStrings).some((mode) =>
+    Object.values(internal_accessModeIriStrings).some((mode) =>
       object.equals(DataFactory.namedNode(mode))
     )
   ) {
@@ -419,11 +425,11 @@ function isAclQuad(quad: Quad): boolean {
  * IRIs of potential Access Modes
  * @internal
  */
-const accessModeIriStrings = {
+export const internal_accessModeIriStrings = {
   read: "http://www.w3.org/ns/auth/acl#Read",
   append: "http://www.w3.org/ns/auth/acl#Append",
   write: "http://www.w3.org/ns/auth/acl#Write",
   control: "http://www.w3.org/ns/auth/acl#Control",
 } as const;
 /** @internal */
-type AccessModeIriString = typeof accessModeIriStrings[keyof typeof accessModeIriStrings];
+type AccessModeIriString = typeof internal_accessModeIriStrings[keyof typeof internal_accessModeIriStrings];

--- a/src/acl/agent.test.ts
+++ b/src/acl/agent.test.ts
@@ -31,6 +31,7 @@ import {
   unstable_setAgentResourceAccessModes,
   unstable_getAgentAccessModesOne,
   unstable_getAgentAccessModesAll,
+  unstable_setAgentDefaultAccessModes,
 } from "./agent";
 import {
   LitDataset,
@@ -1688,5 +1689,555 @@ describe("getAgentDefaultAccessModesAll", () => {
         control: false,
       },
     });
+  });
+});
+
+describe("setAgentDefaultAccessModes", () => {
+  it("adds Quads for the appropriate Access Modes", () => {
+    const sourceDataset = Object.assign(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      { accessTo: "https://arbitrary.pod/container/" }
+    );
+
+    const updatedDataset = unstable_setAgentDefaultAccessModes(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: true,
+        append: true,
+        write: true,
+        control: true,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(6);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Write"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Control"
+    );
+    expect(updatedQuads[4].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#default"
+    );
+    expect(updatedQuads[4].object.value).toBe(
+      "https://arbitrary.pod/container/"
+    );
+    expect(updatedQuads[5].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+    expect(updatedQuads[5].object.value).toBe(
+      "https://some.pod/profileDoc#webId"
+    );
+  });
+
+  it("does not alter the input LitDataset", () => {
+    const sourceDataset = Object.assign(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      { accessTo: "https://arbitrary.pod/container/" }
+    );
+
+    unstable_setAgentDefaultAccessModes(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    expect(Array.from(sourceDataset)).toEqual([]);
+  });
+
+  it("keeps a log of changes made to the ACL", () => {
+    const sourceDataset = Object.assign(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      { accessTo: "https://arbitrary.pod/container/" }
+    );
+
+    const updatedDataset = unstable_setAgentDefaultAccessModes(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const deletedQuads = updatedDataset.changeLog.deletions;
+    expect(deletedQuads).toEqual([]);
+    const addedQuads = updatedDataset.changeLog.additions;
+    expect(addedQuads).toHaveLength(4);
+    expect(addedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(addedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(addedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(addedQuads[1].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(addedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#default"
+    );
+    expect(addedQuads[2].object.value).toBe("https://arbitrary.pod/container/");
+    expect(addedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+    expect(addedQuads[3].object.value).toBe(
+      "https://some.pod/profileDoc#webId"
+    );
+  });
+
+  it("does not forget to add a Quad for Append access if Write access is not given", () => {
+    // This test is basically there to test for regressions
+    // if we ever try to be clever about inferring Append access
+    // (but we should be able to leave that to the server).
+    const sourceDataset = Object.assign(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      { accessTo: "https://arbitrary.pod/container/" }
+    );
+
+    const updatedDataset = unstable_setAgentDefaultAccessModes(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: false,
+        append: true,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Append"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#default"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "https://arbitrary.pod/container/"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "https://some.pod/profileDoc#webId"
+    );
+  });
+
+  it("replaces existing Quads defining Access Modes for this agent", () => {
+    const sourceDataset = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some.pod/profileDoc#webId",
+      "https://arbitrary.pod/container/",
+      { read: false, append: false, write: false, control: true },
+      "default"
+    );
+
+    const updatedDataset = unstable_setAgentDefaultAccessModes(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#default"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "https://arbitrary.pod/container/"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "https://some.pod/profileDoc#webId"
+    );
+  });
+
+  it("removes all Quads for an ACL rule if it no longer applies to anything", () => {
+    const sourceDataset = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some.pod/profileDoc#webId",
+      "https://arbitrary.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "default"
+    );
+
+    const updatedDataset = unstable_setAgentDefaultAccessModes(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toEqual([]);
+  });
+
+  it("does not remove ACL rules that apply to the Agent but also act as resource rules", () => {
+    const sourceDataset = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some.pod/profileDoc#webId",
+      "https://arbitrary.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "default"
+    );
+    const aclRuleSubject = Array.from(sourceDataset)[0].subject;
+    sourceDataset.add(
+      DataFactory.quad(
+        aclRuleSubject,
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#accessTo"),
+        DataFactory.namedNode("https://arbitrary.pod/container/")
+      )
+    );
+
+    const updatedDataset = unstable_setAgentDefaultAccessModes(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#accessTo"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "https://arbitrary.pod/container/"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "https://some.pod/profileDoc#webId"
+    );
+  });
+
+  it("does not remove ACL rules that apply to the Agent but also apply to a different Container", () => {
+    const sourceDataset = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some.pod/profileDoc#webId",
+      "https://arbitrary.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "default"
+    );
+    const aclRuleSubject = Array.from(sourceDataset)[0].subject;
+    sourceDataset.add(
+      DataFactory.quad(
+        aclRuleSubject,
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#default"),
+        DataFactory.namedNode("https://arbitrary.pod/other-container/")
+      )
+    );
+
+    const updatedDataset = unstable_setAgentDefaultAccessModes(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#default"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "https://arbitrary.pod/other-container/"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "https://some.pod/profileDoc#webId"
+    );
+  });
+
+  it("does not remove ACL rules that no longer apply to the given Agent, but still apply to others", () => {
+    const sourceDataset = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some.pod/profileDoc#webId",
+      "https://arbitrary.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "default"
+    );
+    const aclRuleSubject = Array.from(sourceDataset)[0].subject;
+    sourceDataset.add(
+      DataFactory.quad(
+        aclRuleSubject,
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agent"),
+        DataFactory.namedNode("https://some-other.pod/profileDoc#webId")
+      )
+    );
+
+    const updatedDataset = unstable_setAgentDefaultAccessModes(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#default"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "https://arbitrary.pod/container/"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "https://some-other.pod/profileDoc#webId"
+    );
+  });
+
+  it("does not remove ACL rules that no longer apply to the given Agent, but still apply to non-Agents", () => {
+    const sourceDataset = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some.pod/profileDoc#webId",
+      "https://arbitrary.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "default"
+    );
+    const aclRuleSubject = Array.from(sourceDataset)[0].subject;
+    sourceDataset.add(
+      DataFactory.quad(
+        aclRuleSubject,
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agentClass"),
+        DataFactory.namedNode("http://xmlns.com/foaf/0.1/Agent")
+      )
+    );
+
+    const updatedDataset = unstable_setAgentDefaultAccessModes(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#default"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "https://arbitrary.pod/container/"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agentClass"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "http://xmlns.com/foaf/0.1/Agent"
+    );
+  });
+
+  it("does not change ACL rules that also apply to other Agents", () => {
+    const sourceDataset = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some.pod/profileDoc#webId",
+      "https://arbitrary.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "default"
+    );
+    const aclRuleSubject = Array.from(sourceDataset)[0].subject;
+    sourceDataset.add(
+      DataFactory.quad(
+        aclRuleSubject,
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agent"),
+        DataFactory.namedNode("https://some-other.pod/profileDoc#webId")
+      )
+    );
+
+    const updatedDataset = unstable_setAgentDefaultAccessModes(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: false,
+        append: true,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(8);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#default"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "https://arbitrary.pod/container/"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "https://some-other.pod/profileDoc#webId"
+    );
+    expect(updatedQuads[4].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[4].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[5].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[5].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Append"
+    );
+    expect(updatedQuads[6].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#default"
+    );
+    expect(updatedQuads[6].object.value).toBe(
+      "https://arbitrary.pod/container/"
+    );
+    expect(updatedQuads[7].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+    expect(updatedQuads[7].object.value).toBe(
+      "https://some.pod/profileDoc#webId"
+    );
+    // Make sure the default Access Modes granted in 2 and 5 are in separate ACL Rules:
+    expect(updatedQuads[2].subject.equals(updatedQuads[5].subject)).toBe(false);
   });
 });

--- a/src/acl/agent.test.ts
+++ b/src/acl/agent.test.ts
@@ -20,6 +20,7 @@
  */
 
 import { describe, it, expect } from "@jest/globals";
+import { Quad } from "rdf-js";
 import { dataset } from "@rdfjs/dataset";
 import { DataFactory } from "n3";
 import {
@@ -27,6 +28,7 @@ import {
   unstable_getAgentResourceAccessModesAll,
   unstable_getAgentDefaultAccessModesOne,
   unstable_getAgentDefaultAccessModesAll,
+  unstable_setAgentResourceAccessModes,
   unstable_getAgentAccessModesOne,
   unstable_getAgentAccessModesAll,
 } from "./agent";
@@ -46,7 +48,7 @@ function addAclRuleQuads(
   accessModes: unstable_AccessModes,
   type: "resource" | "default"
 ): unstable_AclDataset {
-  const subjectIri = "#" + encodeURIComponent(agent) + Math.random();
+  const subjectIri = resource + "#" + encodeURIComponent(agent) + Math.random();
   aclDataset.add(
     DataFactory.quad(
       DataFactory.namedNode(subjectIri),
@@ -845,6 +847,542 @@ describe("getAgentResourceAccessModesAll", () => {
         control: false,
       },
     });
+  });
+});
+
+describe("setAgentResourceAccessModes", () => {
+  it("adds Quads for the appropriate Access Modes", () => {
+    const sourceDataset = Object.assign(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      { accessTo: "https://arbitrary.pod/resource" }
+    );
+
+    const updatedDataset = unstable_setAgentResourceAccessModes(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: true,
+        append: true,
+        write: true,
+        control: true,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(6);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Write"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Control"
+    );
+    expect(updatedQuads[4].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#accessTo"
+    );
+    expect(updatedQuads[4].object.value).toBe("https://arbitrary.pod/resource");
+    expect(updatedQuads[5].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+    expect(updatedQuads[5].object.value).toBe(
+      "https://some.pod/profileDoc#webId"
+    );
+  });
+
+  it("does not alter the input LitDataset", () => {
+    const sourceDataset = Object.assign(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      { accessTo: "https://arbitrary.pod/resource" }
+    );
+
+    unstable_setAgentResourceAccessModes(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    expect(Array.from(sourceDataset)).toEqual([]);
+  });
+
+  it("keeps a log of changes made to the ACL", () => {
+    const sourceDataset = Object.assign(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      { accessTo: "https://arbitrary.pod/resource" }
+    );
+
+    const updatedDataset = unstable_setAgentResourceAccessModes(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const deletedQuads = updatedDataset.changeLog.deletions;
+    expect(deletedQuads).toEqual([]);
+    const addedQuads = updatedDataset.changeLog.additions;
+    expect(addedQuads).toHaveLength(4);
+    expect(addedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(addedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(addedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(addedQuads[1].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(addedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#accessTo"
+    );
+    expect(addedQuads[2].object.value).toBe("https://arbitrary.pod/resource");
+    expect(addedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+    expect(addedQuads[3].object.value).toBe(
+      "https://some.pod/profileDoc#webId"
+    );
+  });
+
+  it("does not forget to add a Quad for Append access if Write access is not given", () => {
+    // This test is basically there to test for regressions
+    // if we ever try to be clever about inferring Append access
+    // (but we should be able to leave that to the server).
+    const sourceDataset = Object.assign(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      { accessTo: "https://arbitrary.pod/resource" }
+    );
+
+    const updatedDataset = unstable_setAgentResourceAccessModes(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: false,
+        append: true,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Append"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#accessTo"
+    );
+    expect(updatedQuads[2].object.value).toBe("https://arbitrary.pod/resource");
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "https://some.pod/profileDoc#webId"
+    );
+  });
+
+  it("replaces existing Quads defining Access Modes for this agent", () => {
+    const sourceDataset = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://some.pod/profileDoc#webId",
+      "https://arbitrary.pod/resource",
+      { read: false, append: false, write: false, control: true },
+      "resource"
+    );
+
+    const updatedDataset = unstable_setAgentResourceAccessModes(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#accessTo"
+    );
+    expect(updatedQuads[2].object.value).toBe("https://arbitrary.pod/resource");
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "https://some.pod/profileDoc#webId"
+    );
+  });
+
+  it("removes all Quads for an ACL rule if it no longer applies to anything", () => {
+    const sourceDataset = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://some.pod/profileDoc#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+
+    const updatedDataset = unstable_setAgentResourceAccessModes(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toEqual([]);
+  });
+
+  it("does not remove ACL rules that apply to the Agent but also act as default rules", () => {
+    const sourceDataset = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some.pod/profileDoc#webId",
+      "https://arbitrary.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+    const aclRuleSubject = Array.from(sourceDataset)[0].subject;
+    sourceDataset.add(
+      DataFactory.quad(
+        aclRuleSubject,
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#default"),
+        DataFactory.namedNode("https://arbitrary.pod/container/")
+      )
+    );
+
+    const updatedDataset = unstable_setAgentResourceAccessModes(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#default"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "https://arbitrary.pod/container/"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "https://some.pod/profileDoc#webId"
+    );
+  });
+
+  it("does not remove ACL rules that apply to the Agent but also apply to a different Resource", () => {
+    const sourceDataset = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://some.pod/profileDoc#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+    const aclRuleSubject = Array.from(sourceDataset)[0].subject;
+    sourceDataset.add(
+      DataFactory.quad(
+        aclRuleSubject,
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#accessTo"),
+        DataFactory.namedNode("https://arbitrary.pod/other-resource")
+      )
+    );
+
+    const updatedDataset = unstable_setAgentResourceAccessModes(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#accessTo"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "https://arbitrary.pod/other-resource"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "https://some.pod/profileDoc#webId"
+    );
+  });
+
+  it("does not remove ACL rules that no longer apply to the given Agent, but still apply to others", () => {
+    const sourceDataset = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://some.pod/profileDoc#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+    const aclRuleSubject = Array.from(sourceDataset)[0].subject;
+    sourceDataset.add(
+      DataFactory.quad(
+        aclRuleSubject,
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agent"),
+        DataFactory.namedNode("https://some-other.pod/profileDoc#webId")
+      )
+    );
+
+    const updatedDataset = unstable_setAgentResourceAccessModes(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#accessTo"
+    );
+    expect(updatedQuads[1].object.value).toBe("https://arbitrary.pod/resource");
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "https://some-other.pod/profileDoc#webId"
+    );
+  });
+
+  it("does not remove ACL rules that no longer apply to the given Agent, but still apply to non-Agents", () => {
+    const sourceDataset = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://some.pod/profileDoc#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+    const aclRuleSubject = Array.from(sourceDataset)[0].subject;
+    sourceDataset.add(
+      DataFactory.quad(
+        aclRuleSubject,
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agentClass"),
+        DataFactory.namedNode("http://xmlns.com/foaf/0.1/Agent")
+      )
+    );
+
+    const updatedDataset = unstable_setAgentResourceAccessModes(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#accessTo"
+    );
+    expect(updatedQuads[1].object.value).toBe("https://arbitrary.pod/resource");
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agentClass"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "http://xmlns.com/foaf/0.1/Agent"
+    );
+  });
+
+  it("does not change ACL rules that also apply to other Agents", () => {
+    const sourceDataset = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://some.pod/profileDoc#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+    const aclRuleSubject = Array.from(sourceDataset)[0].subject;
+    sourceDataset.add(
+      DataFactory.quad(
+        aclRuleSubject,
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agent"),
+        DataFactory.namedNode("https://some-other.pod/profileDoc#webId")
+      )
+    );
+
+    const updatedDataset = unstable_setAgentResourceAccessModes(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: false,
+        append: true,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(8);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#accessTo"
+    );
+    expect(updatedQuads[1].object.value).toBe("https://arbitrary.pod/resource");
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "https://some-other.pod/profileDoc#webId"
+    );
+    expect(updatedQuads[4].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[4].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[5].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[5].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Append"
+    );
+    expect(updatedQuads[6].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#accessTo"
+    );
+    expect(updatedQuads[6].object.value).toBe("https://arbitrary.pod/resource");
+    expect(updatedQuads[7].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+    expect(updatedQuads[7].object.value).toBe(
+      "https://some.pod/profileDoc#webId"
+    );
+    // Make sure the Access Modes granted in 2 and 5 are in separate ACL Rules:
+    expect(updatedQuads[2].subject.equals(updatedQuads[5].subject)).toBe(false);
   });
 });
 

--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -21,13 +21,15 @@
 
 import {
   WebId,
+  WithChangeLog,
   unstable_WithAcl,
   unstable_AclDataset,
   unstable_AccessModes,
   unstable_AclRule,
+  IriString,
 } from "../interfaces";
 import { getIriOne, getIriAll } from "../thing/get";
-import { acl } from "../constants";
+import { acl, rdf } from "../constants";
 import {
   internal_getAclRules,
   internal_getResourceAclRulesForResource,
@@ -38,7 +40,13 @@ import {
   unstable_getResourceAcl,
   unstable_hasFallbackAcl,
   unstable_getFallbackAcl,
+  internal_accessModeIriStrings,
+  internal_removeEmptyAclRules,
 } from "../acl";
+import { createThing, getThingAll, setThing } from "../thing";
+import { removeIri } from "../thing/remove";
+import { setIri } from "../thing/set";
+import { addIri } from "../thing/add";
 
 export type unstable_AgentAccess = Record<WebId, unstable_AccessModes>;
 
@@ -148,6 +156,57 @@ export function unstable_getAgentResourceAccessModesAll(
 }
 
 /**
+ * Given an ACL LitDataset, modify the ACL Rules to set specific Access Modes for a given Agent.
+ *
+ * If the given ACL LitDataset already includes ACL Rules that grant a certain set of Access Modes
+ * to the given Agent, those will be overridden by the given Access Modes.
+ *
+ * Keep in mind that this function will not modify:
+ * - access arbitrary Agents might have been given through other ACL rules, e.g. public or group-specific permissions.
+ * - what access arbitrary Agents have to child Resources.
+ *
+ * Also, please note that this function is still experimental: its API can change in non-major releases.
+ *
+ * @param aclDataset The LitDataset that contains Access-Control List rules.
+ * @param agent The Agent to grant specific Access Modes.
+ * @param accessModes The Access Modes to grant to the Agent.
+ */
+export function unstable_setAgentResourceAccessModes(
+  aclDataset: unstable_AclDataset,
+  agent: WebId,
+  accessModes: unstable_AccessModes
+): unstable_AclDataset & WithChangeLog {
+  // First make sure that none of the pre-existing rules in the given ACL LitDataset
+  // give the Agent access to the Resource:
+  let filteredAcl = aclDataset;
+  getThingAll(aclDataset).forEach((aclRule) => {
+    // Obtain both the Rule that no longer includes the given Agent,
+    // and a new Rule that includes all ACL Quads
+    // that do not pertain to the given Agent-Resource combination.
+    // Note that usually, the latter will no longer include any meaningful statements;
+    // we'll clean them up afterwards.
+    const [filteredRule, remainingRule] = removeAgentFromResourceRule(
+      aclRule,
+      agent,
+      aclDataset.accessTo
+    );
+    filteredAcl = setThing(filteredAcl, filteredRule);
+    filteredAcl = setThing(filteredAcl, remainingRule);
+  });
+
+  // Create a new Rule that only grants the given Agent the given Access Modes:
+  let newRule = intialiseAclRule(accessModes);
+  newRule = setIri(newRule, acl.accessTo, aclDataset.accessTo);
+  newRule = setIri(newRule, acl.agent, agent);
+  const updatedAcl = setThing(filteredAcl, newRule);
+
+  // Remove any remaining Rules that do not contain any meaningful statements:
+  const cleanedAcl = internal_removeEmptyAclRules(updatedAcl);
+
+  return cleanedAcl;
+}
+
+/**
  * Given an ACL LitDataset, find out which access modes it provides to an Agent for the associated Container Resource's child Resources.
  *
  * Keep in mind that this function will not tell you:
@@ -216,6 +275,86 @@ function getAgentAclRules(aclRules: unstable_AclRule[]): unstable_AclRule[] {
 
 function isAgentAclRule(aclRule: unstable_AclRule): boolean {
   return getIriOne(aclRule, acl.agent) !== null;
+}
+
+/**
+ * Create a new ACL Rule with the same ACL values as the input ACL Rule, but having a different IRI.
+ *
+ * Note that non-ACL values will not be copied over.
+ *
+ * @param sourceRule ACL rule to duplicate.
+ */
+function duplicateAclRule(sourceRule: unstable_AclRule): unstable_AclRule {
+  let targetRule = createThing();
+  targetRule = setIri(targetRule, rdf.type, acl.Authorization);
+
+  function copyIris(
+    inputRule: typeof sourceRule,
+    outputRule: typeof targetRule,
+    predicate: IriString
+  ) {
+    return getIriAll(inputRule, predicate).reduce(
+      (outputRule, iriTarget) => addIri(outputRule, predicate, iriTarget),
+      outputRule
+    );
+  }
+
+  targetRule = copyIris(sourceRule, targetRule, acl.accessTo);
+  targetRule = copyIris(sourceRule, targetRule, acl.default);
+  targetRule = copyIris(sourceRule, targetRule, acl.agent);
+  targetRule = copyIris(sourceRule, targetRule, acl.agentGroup);
+  targetRule = copyIris(sourceRule, targetRule, acl.agentClass);
+  targetRule = copyIris(sourceRule, targetRule, acl.origin);
+  targetRule = copyIris(sourceRule, targetRule, acl.mode);
+
+  return targetRule;
+}
+
+/**
+ * Given an ACL Rule, return two new ACL Rules that cover all the input Rule's use cases,
+ * except for giving the given Agent access to the given Resource.
+ *
+ * @param rule The ACL Rule that should no longer apply for a given Agent to a given Resource.
+ * @param agent The Agent that should be removed from the Rule for the given Resource.
+ * @param resourceIri The Resource to which the Rule should no longer apply for the given Agent.
+ * @returns A tuple with the original ACL Rule sans the given Agent, and a new ACL Rule for the given Agent for the remaining Resources, respectively.
+ */
+function removeAgentFromResourceRule(
+  rule: unstable_AclRule,
+  agent: WebId,
+  resourceIri: IriString
+): [unstable_AclRule, unstable_AclRule] {
+  // The existing rule will keep applying to Agents other than the given one:
+  let ruleWithoutAgent = removeIri(rule, acl.agent, agent);
+  // The new rule will...
+  let ruleForOtherTargets = duplicateAclRule(rule);
+  // ...*only* apply to the given Agent (because the existing Rule covers the others)...
+  ruleForOtherTargets = setIri(ruleForOtherTargets, acl.agent, agent);
+  // ...but not to the given Resource:
+  ruleForOtherTargets = removeIri(
+    ruleForOtherTargets,
+    acl.accessTo,
+    resourceIri
+  );
+  return [ruleWithoutAgent, ruleForOtherTargets];
+}
+
+function intialiseAclRule(accessModes: unstable_AccessModes): unstable_AclRule {
+  let newRule = createThing();
+  newRule = setIri(newRule, rdf.type, acl.Authorization);
+  if (accessModes.read) {
+    newRule = addIri(newRule, acl.mode, internal_accessModeIriStrings.read);
+  }
+  if (accessModes.append && !accessModes.write) {
+    newRule = addIri(newRule, acl.mode, internal_accessModeIriStrings.append);
+  }
+  if (accessModes.write) {
+    newRule = addIri(newRule, acl.mode, internal_accessModeIriStrings.write);
+  }
+  if (accessModes.control) {
+    newRule = addIri(newRule, acl.mode, internal_accessModeIriStrings.control);
+  }
+  return newRule;
 }
 
 function getAccessModesByAgent(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,8 +27,11 @@ export const acl = {
   Authorization: "http://www.w3.org/ns/auth/acl#Authorization",
   accessTo: "http://www.w3.org/ns/auth/acl#accessTo",
   agent: "http://www.w3.org/ns/auth/acl#agent",
+  agentGroup: "http://www.w3.org/ns/auth/acl#agentGroup",
+  agentClass: "http://www.w3.org/ns/auth/acl#agentClass",
   default: "http://www.w3.org/ns/auth/acl#default",
   mode: "http://www.w3.org/ns/auth/acl#mode",
+  origin: "http://www.w3.org/ns/auth/acl#origin",
 } as const;
 
 /** @internal */

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -99,6 +99,7 @@ import {
   unstable_setAgentResourceAccessModes,
   unstable_getAgentDefaultAccessModesOne,
   unstable_getAgentDefaultAccessModesAll,
+  unstable_setAgentDefaultAccessModes,
   // Deprecated functions still exported for backwards compatibility:
   getStringUnlocalizedOne,
   getStringUnlocalizedAll,
@@ -194,6 +195,7 @@ it("exports the public API from the entry file", () => {
   expect(unstable_setAgentResourceAccessModes).toBeDefined();
   expect(unstable_getAgentDefaultAccessModesOne).toBeDefined();
   expect(unstable_getAgentDefaultAccessModesAll).toBeDefined();
+  expect(unstable_setAgentDefaultAccessModes).toBeDefined();
 });
 
 it("still exports deprecated methods", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -96,6 +96,7 @@ import {
   unstable_getAgentAccessModesAll,
   unstable_getAgentResourceAccessModesOne,
   unstable_getAgentResourceAccessModesAll,
+  unstable_setAgentResourceAccessModes,
   unstable_getAgentDefaultAccessModesOne,
   unstable_getAgentDefaultAccessModesAll,
   // Deprecated functions still exported for backwards compatibility:
@@ -190,6 +191,7 @@ it("exports the public API from the entry file", () => {
   expect(unstable_getAgentAccessModesAll).toBeDefined();
   expect(unstable_getAgentResourceAccessModesOne).toBeDefined();
   expect(unstable_getAgentResourceAccessModesAll).toBeDefined();
+  expect(unstable_setAgentResourceAccessModes).toBeDefined();
   expect(unstable_getAgentDefaultAccessModesOne).toBeDefined();
   expect(unstable_getAgentDefaultAccessModesAll).toBeDefined();
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,6 +140,7 @@ export {
   unstable_setAgentResourceAccessModes,
   unstable_getAgentDefaultAccessModesOne,
   unstable_getAgentDefaultAccessModesAll,
+  unstable_setAgentDefaultAccessModes,
 } from "./acl/agent";
 export {
   Url,

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,7 @@ export {
   unstable_getAgentAccessModesAll,
   unstable_getAgentResourceAccessModesOne,
   unstable_getAgentResourceAccessModesAll,
+  unstable_setAgentResourceAccessModes,
   unstable_getAgentDefaultAccessModesOne,
   unstable_getAgentDefaultAccessModesAll,
 } from "./acl/agent";


### PR DESCRIPTION
# New feature description

Given an ACL LitDataset, this PR adds `setAgentResourceAccessModes()` and `setAgentDefaultAccessModes()` that take an object with access modes (Read, Append, Write and/or Control), and make sure that the given modes are granted for the agent as resource or default access, respectively, and that any existing agent-specific modes that are _not_ given are revoked.

Note that the approach is rather convoluted, though I'm not sure if there's a better way. Specifically, what these functions do:

1. For every existing Access Rule that applies to the given Agent and the given Resource, remove the Agent from that Rule, and create a new Rule that duplicates all existing ACL-related Quads, _except_ for the ones that make the Rule apply to the given Resource. In the common case, this should result in a new Rule that does not have any effect - see step 3.
2. Add a new Access Rule that sets the passed Access Modes for the given Agent and the given Resource. (For either Resource access or default access, depending on the function.)
3. Remove all Things that contain _only_ ACL-related Quads, but that do not have any effect, e.g. because no Resource to which it applies is specified, or because it doesn't specify _who_ is granted access.

It's somewhat convoluted but, assuming that the clean-up function is accurate, the only way that feels safe to me. Most of that work should also be re-usable when adding support for setting e.g. public or group access, in the future, which will run into the same concerns.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated. -> Tutorial will be added when you can also save the updated ACL back to the Pod.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
