### PR TITLE
Implement saveAclFor()

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -29,6 +29,7 @@ import {
   unstable_fetchResourceInfoWithAcl,
   saveLitDatasetAt,
   saveLitDatasetInContainer,
+  unstable_saveAclFor,
   getThingOne,
   getThingAll,
   setThing,
@@ -123,6 +124,7 @@ it("exports the public API from the entry file", () => {
   expect(unstable_fetchResourceInfoWithAcl).toBeDefined();
   expect(saveLitDatasetAt).toBeDefined();
   expect(saveLitDatasetInContainer).toBeDefined();
+  expect(unstable_saveAclFor).toBeDefined();
   expect(getThingOne).toBeDefined();
   expect(getThingAll).toBeDefined();
   expect(setThing).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export {
   saveLitDatasetAt,
   saveLitDatasetInContainer,
   unstable_fetchLitDatasetWithAcl,
+  unstable_saveAclFor,
 } from "./litDataset";
 export {
   getThingOne,

--- a/src/litDataset.ts
+++ b/src/litDataset.ts
@@ -37,6 +37,7 @@ import {
   unstable_WithAcl,
   unstable_hasAccessibleAcl,
   unstable_AccessModes,
+  unstable_AclDataset,
 } from "./interfaces";
 
 /**
@@ -406,6 +407,38 @@ export async function saveLitDatasetInContainer(
   );
 
   return resourceWithResolvedIris;
+}
+
+/**
+ * Save the ACL for a Resource.
+ *
+ * @param resource The Resource to which the given ACL applies.
+ * @param resourceAcl An [[unstable_AclDataset]] whose ACL Rules will apply to `resource`.
+ * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ */
+export async function unstable_saveAclFor(
+  resource: WithResourceInfo & {
+    resourceInfo: {
+      unstable_aclUrl: Exclude<
+        WithResourceInfo["resourceInfo"]["unstable_aclUrl"],
+        undefined
+      >;
+    };
+  },
+  resourceAcl: unstable_AclDataset,
+  options: Partial<typeof defaultSaveOptions> = defaultSaveOptions
+): Promise<unstable_AclDataset & WithResourceInfo> {
+  const savedDataset = await saveLitDatasetAt(
+    resource.resourceInfo.unstable_aclUrl,
+    resourceAcl,
+    options
+  );
+  const savedAclDataset: unstable_AclDataset &
+    typeof savedDataset = Object.assign(savedDataset, {
+    accessTo: resource.resourceInfo.fetchedFrom,
+  });
+
+  return savedAclDataset;
 }
 
 function getNamedNodesForLocalNodes(quad: Quad): Quad {


### PR DESCRIPTION
# New feature description

This adds the ability to save an ACL Resource back to the Pod, to associate it with the given Resource.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated. (API docs are there, tutorial update will follow later.)
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
