### PR TITLE
Add aliases for complex types

### DIFF
--- a/src/acl.ts
+++ b/src/acl.ts
@@ -36,6 +36,8 @@ import {
   IriString,
   unstable_WithAcl,
   unstable_WithAccessibleAcl,
+  unstable_WithResourceAcl,
+  unstable_WithFallbackAcl,
 } from "./interfaces";
 import { getThingAll, removeThing } from "./thing";
 import { getIriOne, getIriAll } from "./thing/get";
@@ -134,11 +136,9 @@ export function unstable_hasResourceAcl<
   Resource extends unstable_WithAcl & WithResourceInfo
 >(
   resource: Resource
-): resource is Resource & {
-  acl: {
-    resourceAcl: Exclude<unstable_WithAcl["acl"]["resourceAcl"], null>;
-  };
-} & unstable_WithAccessibleAcl {
+): resource is Resource &
+  unstable_WithResourceAcl &
+  unstable_WithAccessibleAcl {
   return (
     resource.acl.resourceAcl !== null &&
     resource.resourceInfo.fetchedFrom === resource.acl.resourceAcl.accessTo &&
@@ -157,12 +157,7 @@ export function unstable_hasResourceAcl<
  * @returns The ACL, if available, and undefined if not.
  */
 export function unstable_getResourceAcl(
-  resource: unstable_WithAcl &
-    WithResourceInfo & {
-      acl: {
-        resourceAcl: Exclude<unstable_WithAcl["acl"]["resourceAcl"], null>;
-      };
-    }
+  resource: unstable_WithAcl & WithResourceInfo & unstable_WithResourceAcl
 ): unstable_AclDataset;
 export function unstable_getResourceAcl(
   resource: unstable_WithAcl & WithResourceInfo
@@ -190,11 +185,7 @@ export function unstable_getResourceAcl(
  */
 export function unstable_hasFallbackAcl<Resource extends unstable_WithAcl>(
   resource: Resource
-): resource is Resource & {
-  acl: {
-    fallbackAcl: Exclude<unstable_WithAcl["acl"]["fallbackAcl"], null>;
-  };
-} {
+): resource is unstable_WithFallbackAcl<Resource> {
   return resource.acl.fallbackAcl !== null;
 }
 
@@ -208,11 +199,7 @@ export function unstable_hasFallbackAcl<Resource extends unstable_WithAcl>(
  * @returns The fallback ACL, or null if it coult not be accessed.
  */
 export function unstable_getFallbackAcl(
-  resource: unstable_WithAcl & {
-    acl: {
-      fallbackAcl: Exclude<unstable_WithAcl["acl"]["fallbackAcl"], null>;
-    };
-  }
+  resource: unstable_WithFallbackAcl
 ): unstable_AclDataset;
 export function unstable_getFallbackAcl(
   dataset: unstable_WithAcl

--- a/src/acl.ts
+++ b/src/acl.ts
@@ -35,6 +35,7 @@ import {
   Thing,
   IriString,
   unstable_WithAcl,
+  unstable_WithAccessibleAcl,
 } from "./interfaces";
 import { getThingAll, removeThing } from "./thing";
 import { getIriOne, getIriAll } from "./thing/get";
@@ -67,17 +68,10 @@ export async function internal_fetchResourceAcl(
 
 /** @internal */
 export async function internal_fetchFallbackAcl(
-  dataset: WithResourceInfo & {
-    resourceInfo: {
-      unstable_aclUrl: Exclude<
-        WithResourceInfo["resourceInfo"]["unstable_aclUrl"],
-        undefined
-      >;
-    };
-  },
+  resource: unstable_WithAccessibleAcl,
   options: Partial<typeof defaultFetchOptions> = defaultFetchOptions
 ): Promise<unstable_AclDataset | null> {
-  const resourceUrl = new URL(dataset.resourceInfo.fetchedFrom);
+  const resourceUrl = new URL(resource.resourceInfo.fetchedFrom);
   const resourcePath = resourceUrl.pathname;
   // Note: we're currently assuming that the Origin is the root of the Pod. However, it is not yet
   //       set in stone that that will always be the case. We might need to check the Container's
@@ -144,14 +138,7 @@ export function unstable_hasResourceAcl<
   acl: {
     resourceAcl: Exclude<unstable_WithAcl["acl"]["resourceAcl"], null>;
   };
-} & {
-  resourceInfo: {
-    unstable_aclUrl: Exclude<
-      WithResourceInfo["resourceInfo"]["unstable_aclUrl"],
-      undefined
-    >;
-  };
-} {
+} & unstable_WithAccessibleAcl {
   return (
     resource.acl.resourceAcl !== null &&
     resource.resourceInfo.fetchedFrom === resource.acl.resourceAcl.accessTo &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,6 +156,7 @@ export {
   LocalNode,
   WithResourceInfo,
   WithChangeLog,
+  unstable_WithAccessibleAcl,
   unstable_WithAcl,
   unstable_AclDataset,
   unstable_AclRule,

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,6 +158,8 @@ export {
   WithChangeLog,
   unstable_WithAccessibleAcl,
   unstable_WithAcl,
+  unstable_WithFallbackAcl,
+  unstable_WithResourceAcl,
   unstable_AclDataset,
   unstable_AclRule,
   unstable_AccessModes,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -153,6 +153,28 @@ export type unstable_WithAcl = {
 };
 
 /**
+ * If this type applies to a Resource, an Access Control List that applies to it exists and is accessible to the currently authenticated user.
+ */
+export type unstable_WithResourceAcl<
+  Resource extends unstable_WithAcl = unstable_WithAcl
+> = Resource & {
+  acl: {
+    resourceAcl: Exclude<unstable_WithAcl["acl"]["resourceAcl"], null>;
+  };
+};
+
+/**
+ * If this type applies to a Resource, the Access Control List that applies to its nearest Container with an ACL is accessible to the currently authenticated user.
+ */
+export type unstable_WithFallbackAcl<
+  Resource extends unstable_WithAcl = unstable_WithAcl
+> = Resource & {
+  acl: {
+    fallbackAcl: Exclude<unstable_WithAcl["acl"]["fallbackAcl"], null>;
+  };
+};
+
+/**
  * Verify whether a given LitDataset includes metadata about where it was retrieved from.
  *
  * @param dataset A [[LitDataset]] that may have metadata attached about the Resource it was retrieved from.

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -178,6 +178,20 @@ export function hasChangelog<T extends LitDataset>(
 }
 
 /**
+ * If this type applies to a Resource, its Access Control List, if it exists, is accessible to the currently authenticated user.
+ */
+export type unstable_WithAccessibleAcl<
+  Resource extends WithResourceInfo = WithResourceInfo
+> = Resource & {
+  resourceInfo: {
+    unstable_aclUrl: Exclude<
+      WithResourceInfo["resourceInfo"]["unstable_aclUrl"],
+      undefined
+    >;
+  };
+};
+
+/**
  * Given a [[LitDataset]], verify whether it has ACL data attached to it.
  *
  * This should generally only be true for LitDatasets fetched by
@@ -187,11 +201,9 @@ export function hasChangelog<T extends LitDataset>(
  * @returns Whether the given `dataset` has ACL data attached to it.
  * @internal
  */
-export function unstable_hasAccessibleAcl<Dataset extends WithResourceInfo>(
-  dataset: Dataset
-): dataset is Dataset & {
-  resourceInfo: { unstable_aclUrl: UrlString };
-} {
+export function unstable_hasAccessibleAcl<Resource extends WithResourceInfo>(
+  dataset: Resource
+): dataset is unstable_WithAccessibleAcl<Resource> {
   return typeof dataset.resourceInfo.unstable_aclUrl === "string";
 }
 

--- a/src/litDataset.ts
+++ b/src/litDataset.ts
@@ -38,6 +38,7 @@ import {
   unstable_hasAccessibleAcl,
   unstable_AccessModes,
   unstable_AclDataset,
+  unstable_WithAccessibleAcl,
 } from "./interfaces";
 
 /**
@@ -417,14 +418,7 @@ export async function saveLitDatasetInContainer(
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  */
 export async function unstable_saveAclFor(
-  resource: WithResourceInfo & {
-    resourceInfo: {
-      unstable_aclUrl: Exclude<
-        WithResourceInfo["resourceInfo"]["unstable_aclUrl"],
-        undefined
-      >;
-    };
-  },
+  resource: unstable_WithAccessibleAcl,
   resourceAcl: unstable_AclDataset,
   options: Partial<typeof defaultSaveOptions> = defaultSaveOptions
 ): Promise<unstable_AclDataset & WithResourceInfo> {


### PR DESCRIPTION
# New feature description

We had a couple of complex types that basically verified that a potentially-non-existent property of another type existed. This adds type aliases for those to make the code a bit easier to follow and to enable developers to easily re-use them.

Originally brought up here: https://github.com/inrupt/lit-pod/pull/200#discussion_r446202663

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
