### PR TITLE
Remove redundant generic in type guard

### DIFF
--- a/src/acl.ts
+++ b/src/acl.ts
@@ -185,7 +185,7 @@ export function unstable_getResourceAcl(
  */
 export function unstable_hasFallbackAcl<Resource extends unstable_WithAcl>(
   resource: Resource
-): resource is unstable_WithFallbackAcl<Resource> {
+): resource is Resource & unstable_WithFallbackAcl {
   return resource.acl.fallbackAcl !== null;
 }
 


### PR DESCRIPTION
Since we already added `Resource` to the union type of
WithFallbackAcl, there is no need to also pass it to
WithFallbackAcl so it can add it to its own union.

(And more importantly, the generic in the type guard's return type
leads to the website build failing, in yet another instance of
https://github.com/tgreyuk/typedoc-plugin-markdown/pull/128.)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
