### PR TITLE
Add an introductory guide

### DIFF
--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -24,6 +24,12 @@ If no such authenticated fetcher is provided, only public [Resources](./glossary
 
 ## Quick start
 
+:::info
+
+If you are looking for a more thorough introduction, you can work your way through the full [Guide](./guide/installation).
+
+:::
+
 ### Fetching data
 
 ```typescript

--- a/website/docs/guide/core-concepts.md
+++ b/website/docs/guide/core-concepts.md
@@ -1,0 +1,33 @@
+---
+id: core-concepts
+title: Core Concepts
+sidebar_label: Core Concepts
+---
+
+## Fetching data
+
+In general, working with data using lit-pod involves two steps: making a request to some web address (URL) to fetch an object containing all data at that address (a [`LitDataset`](../glossary#litdataset)), and then passing that object to functions to extract and manipulate sets of data from it that are relevant to you (which we call [`Thing`s](../glossary#thing)).
+
+<!--
+
+TODO:
+If the spec gets updated to support atomic fetching and updates of multiple Named Graphs at the same Resource,
+this section should be updated to clarify that; the slicing-and-dicing idea might make more sense with that context.
+
+-->
+
+For example, to read my name, you would first fetch a LitDataset from `https://vincentt.inrupt.net/profile/card`, the URL at which my personal information is stored. Then, from that LitDataset, you could extract the Thing that represents my profile. From that, you can then read my name.
+
+For a more extensive overview of fetching and manipulating data, see the tutorial [Working with Data](../tutorials/working-with-data).
+
+## Immutability
+
+The functions exposed in lit-pod are designed to take data as input, apply some transformation, and return the transformed data as output **without changing the input data**. That makes it easier for you to write unit tests, and enables frameworks that want to be notified of changes to data (like most modern front-end frameworks) to apply performance optimizations like memoisation, checking for updates by references rather than doing deep comparisons. However, it is good to be aware of this fact; when you're seeing stale data, that is likely the result of a variable pointing to an input value, rather than to the returned result.
+
+<!--
+
+TODO:
+Once we add a Fluent API, we should add a section here about gradually exposing advanced interfaces,
+add an "Advanced Usage" section to the documentation, and refer to that.
+
+-->

--- a/website/docs/guide/installation.md
+++ b/website/docs/guide/installation.md
@@ -1,0 +1,17 @@
+---
+id: installation
+title: Installation
+sidebar_label: Installation
+---
+
+To install the latest stable version of lit-pod, run:
+
+```bash
+npm install @solid/lit-pod
+```
+
+lit-pod will work in Node using CommonJS modules, and in the browser with a bundler like [Webpack](https://webpack.js.org), [Rollup](https://rollupjs.org) or [Parcel](https://parceljs.org).
+
+## To access private data
+
+By default, lit-will only enables to access public data on Solid Pods. To allow for access to restricted data, you will need to include a library that supports user authentication. If you have [solid-auth-client](https://www.npmjs.com/package/solid-auth-client) installed and have used it to authenticate the user, lit-pod will automatically pick up the authenticated session and include the user's credentials with each request.

--- a/website/docs/guide/motivation.md
+++ b/website/docs/guide/motivation.md
@@ -1,0 +1,37 @@
+---
+id: motivation
+title: Motivation
+sidebar_label: Motivation
+---
+
+[Solid](https://solidproject.org) is a wonderful project, but the technology it's built on —[RDF](https://en.wikipedia.org/wiki/Resource_Description_Framework)— is unfamiliar to many developers and has a relatively high barrier to entry.
+
+The main goal of lit-pod is to make it as easy as possible for engineers to get started writing apps both for the browser and for Node that store data on Solid Pods by providing an abstraction layer on top of both Solid and RDF principles, without hampering the ability to leverage the more advanced capabilities of RDF if so desired.
+
+## Goals
+
+To achieve this, lit-pod has the following major focus areas.
+
+### Documentation
+
+Clear and extensive documentation is crucial when learning how to work with a new library. If any documentation is missing or is unclear, please [file a bug](https://github.com/inrupt/lit-pod/issues/new?labels=documentation&template=docs_request.md).
+
+### Testing
+
+There's almost nothing as confusing as being unsure whether a bug is in your own code, or in the library you use. To ensure maximum reliability, lit-pod is exposed to an extensive suite of automated tests, achieving 100% branch coverage with its unit tests.
+
+### Interoperability
+
+Whereas lit-pod makes it easy to get started with Solid, it should not lock you in when you are ready to move on to more advanced use cases. That's why lit-pod is compatible with the [RDF/JS specification](https://rdf.js.org), allowing you to seamlessly switch between lit-pod and libraries that support more advanced use cases for RDF.
+
+## Non-goals
+
+To ensure we achieve those goals, it is important to have a clear focus. Therefore, the following areas are out of scope for the foreseeable future.
+
+### Reasoning
+
+While RDF is explicitly designed to support reasoning over data, it is not entirely clear yet how that would work in practice, especially in the context of Solid. Therefore, lit-pod requires you to explicitly indicate what data you are reading/writing, and only data explicitly stated in the target Pod will be considered.  
+
+### Implicit data fetching
+
+Analogous to the previous point, lit-pod will not try to determine where data might live and attempt to transparently fetch it for you. That means that it is up to the developer to determine when to follow a link.

--- a/website/docs/guide/next-steps.md
+++ b/website/docs/guide/next-steps.md
@@ -1,0 +1,23 @@
+---
+id: next-steps
+title: Next Steps
+sidebar_label: Next Steps
+---
+
+Now that you know the general principles behind lit-pod, it's time to do some actual work. Here are some suggested next steps.
+
+## Learn about common tasks
+
+By far the most common task you will do with lit-pod is reading and writing data, so a recommended starting point is the tutorial [Working with Data](../tutorials/working-with-data).
+
+## Read the API documentation
+
+After you have a high-level overview of how to work with lit-pod, but want to know what functionality is available or what parameters you need to pass to a given function, the [API documentation](../api/index) is a good place to go.
+
+## Connect with the community
+
+If you have questions about how to work with lit-pod or just want to share what you're working on, the [Solid forum](https://forum.solidproject.org) is a good place to meet the rest of the community.
+
+## Contribute
+
+If you have ideas on what could change or is unclear, [file an Issue on GitHub](https://github.com/inrupt/lit-pod/issues/new/choose).

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -78,7 +78,7 @@ module.exports = {
         },
         {
           to: "docs/api/index",
-          activeBasePath: "docs/api/index",
+          activeBasePath: "docs/api/",
           label: "API Reference",
           position: "left",
         },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -65,9 +65,15 @@ module.exports = {
       // },
       links: [
         {
-          to: "docs/",
-          activeBasePath: "docs",
+          to: "docs/getting-started",
+          activeBasePath: "docs/getting-started",
           label: "Getting Started",
+          position: "left",
+        },
+        {
+          to: "docs/guide/installation",
+          activeBasePath: "docs/guide/",
+          label: "Guide",
           position: "left",
         },
         {
@@ -91,7 +97,11 @@ module.exports = {
           items: [
             {
               label: "Getting started",
-              to: "docs/",
+              to: "docs/getting-started",
+            },
+            {
+              label: "Guide",
+              to: "docs/guide/installation",
             },
             {
               label: "API Reference",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1,7 +1,38 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 module.exports = {
   // The API sidebar will be automatically generated in CI when running TypeDoc:
   api: {},
   prose: [
+    {
+      type: "category",
+      label: "Guide",
+      items: [
+        "guide/installation",
+        "guide/motivation",
+        "guide/core-concepts",
+        "guide/next-steps",
+      ],
+    },
     {
       type: "category",
       label: "Tutorials",

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -83,12 +83,21 @@ function Home() {
           <div className={styles.buttons}>
             <Link
               className={classnames(
-                "button button--outline button--secondary button--lg",
-                styles.getStarted
+                "button button--secondary button--lg",
+                styles.heroButton
               )}
-              to={useBaseUrl("docs/")}
+              to={useBaseUrl("docs/getting-started")}
             >
               Get Started
+            </Link>
+            <Link
+              className={classnames(
+                "button button--outline button--secondary button--lg",
+                styles.heroButton
+              )}
+              to={useBaseUrl("docs/guide/installation")}
+            >
+              Guide
             </Link>
           </div>
         </div>

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -24,6 +24,10 @@
   justify-content: center;
 }
 
+.heroButton {
+  margin: 0 var(--ifm-spacing-horizontal);
+}
+
 .features {
   display: flex;
   align-items: center;


### PR DESCRIPTION
This adds an introductory guide explaining the background and motivations for lit-pod. It's currently somewhat bare bones, partly because we have a couple of aspirational goals that will be listed here in due time but that we aren't supporting yet (because documentation should only refer to existing features), and partly because we'll want to be intentional about this and go over this together with Product - but at least there's a clear place to put this stuff. The guide is linked to from the header, the footer, and is the secondary call-to-action on the homepage.

This PR supersedes #159, which mostly involved our aspirational documentation. I've left TODOs indicating places where content based on that PR can later be added.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).