### PR TITLE
Allow reading public access to a Resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,5 @@ First release! What's possible with this first release:
 - Store data back to Solid Pods.
 - Read data from datasets.
 - Manipulate data in datasets.
-- Inspect a user's permissions w.r.t. a given Resource. (Experimental.)
-- Retrieve, delete and/or write any file (including non-RDF) from/to a Pod.
+- Inspect a user's and public permissions w.r.t. a given Resource. (Experimental.)
+- Retrieve, delete and/or write any file (including non-RDF) from/to a Pod. (Experimental.)

--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -110,7 +110,7 @@ export function unstable_getAgentAccessModesAll(
  *
  * Keep in mind that this function will not tell you:
  * - what access the given Agent has through other ACL rules, e.g. public or group-specific permissions.
- * - what access the given Agent has to child Resources, in case the associated Resource is a Container.
+ * - what access the given Agent has to child Resources, in case the associated Resource is a Container (see [[unstable_getAgentDefaultAccessModesOne]] for that).
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
@@ -212,7 +212,7 @@ export function unstable_setAgentResourceAccessModes(
  *
  * Keep in mind that this function will not tell you:
  * - what access the given Agent has through other ACL rules, e.g. public or group-specific permissions.
- * - what access the given Agent has to Container Resource itself (see [[unstable_getAgentResourceAccessModesOne]] for that).
+ * - what access the given Agent has to the Container Resource itself (see [[unstable_getAgentResourceAccessModesOne]] for that).
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *

--- a/src/acl/agentClass.test.ts
+++ b/src/acl/agentClass.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import { DataFactory } from "n3";
+import { dataset } from "@rdfjs/dataset";
+import { unstable_getPublicResourceAccessModes } from "./agentClass";
+import {
+  LitDataset,
+  WithResourceInfo,
+  IriString,
+  unstable_AccessModes,
+  unstable_AclDataset,
+} from "../interfaces";
+
+function addAclRuleQuads(
+  aclDataset: LitDataset & WithResourceInfo,
+  resource: IriString,
+  accessModes: unstable_AccessModes,
+  type: "resource" | "default",
+  agentClass:
+    | "http://xmlns.com/foaf/0.1/Agent"
+    | "http://www.w3.org/ns/auth/acl#AuthenticatedAgent"
+): unstable_AclDataset {
+  const subjectIri =
+    resource + "#" + encodeURIComponent(agentClass) + Math.random();
+  aclDataset.add(
+    DataFactory.quad(
+      DataFactory.namedNode(subjectIri),
+      DataFactory.namedNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+      DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Authorization")
+    )
+  );
+  aclDataset.add(
+    DataFactory.quad(
+      DataFactory.namedNode(subjectIri),
+      DataFactory.namedNode(
+        type === "resource"
+          ? "http://www.w3.org/ns/auth/acl#accessTo"
+          : "http://www.w3.org/ns/auth/acl#default"
+      ),
+      DataFactory.namedNode(resource)
+    )
+  );
+  aclDataset.add(
+    DataFactory.quad(
+      DataFactory.namedNode(subjectIri),
+      DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agentClass"),
+      DataFactory.namedNode(agentClass)
+    )
+  );
+  if (accessModes.read) {
+    aclDataset.add(
+      DataFactory.quad(
+        DataFactory.namedNode(subjectIri),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#mode"),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Read")
+      )
+    );
+  }
+  if (accessModes.append) {
+    aclDataset.add(
+      DataFactory.quad(
+        DataFactory.namedNode(subjectIri),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#mode"),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Append")
+      )
+    );
+  }
+  if (accessModes.write) {
+    aclDataset.add(
+      DataFactory.quad(
+        DataFactory.namedNode(subjectIri),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#mode"),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Write")
+      )
+    );
+  }
+  if (accessModes.control) {
+    aclDataset.add(
+      DataFactory.quad(
+        DataFactory.namedNode(subjectIri),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#mode"),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Control")
+      )
+    );
+  }
+
+  return Object.assign(aclDataset, { accessTo: resource });
+}
+
+function getMockDataset(fetchedFrom: IriString): LitDataset & WithResourceInfo {
+  return Object.assign(dataset(), {
+    resourceInfo: {
+      fetchedFrom: fetchedFrom,
+    },
+  });
+}
+
+describe("getPublicResourceAccessModes", () => {
+  it("returns the applicable Access Modes for the Agent Class foaf:Agent", () => {
+    const resourceAcl = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: true },
+      "resource",
+      "http://xmlns.com/foaf/0.1/Agent"
+    );
+
+    const publicAccess = unstable_getPublicResourceAccessModes(resourceAcl);
+
+    expect(publicAccess).toEqual({
+      read: true,
+      append: false,
+      write: false,
+      control: true,
+    });
+  });
+
+  it("combines Access Modes defined for the Agent Class foaf:Agent in separate rules", () => {
+    let resourceAcl = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "http://xmlns.com/foaf/0.1/Agent"
+    );
+    resourceAcl = addAclRuleQuads(
+      resourceAcl,
+      "https://arbitrary.pod/resource",
+      { read: false, append: true, write: false, control: false },
+      "resource",
+      "http://xmlns.com/foaf/0.1/Agent"
+    );
+
+    const agentAccess = unstable_getPublicResourceAccessModes(resourceAcl);
+
+    expect(agentAccess).toEqual({
+      read: true,
+      append: true,
+      write: false,
+      control: false,
+    });
+  });
+
+  it("returns false for all Access Modes if there are no ACL rules for the Agent Class foaf:Agent", () => {
+    const resourceAcl = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "http://www.w3.org/ns/auth/acl#AuthenticatedAgent"
+    );
+
+    const agentAccess = unstable_getPublicResourceAccessModes(resourceAcl);
+
+    expect(agentAccess).toEqual({
+      read: false,
+      append: false,
+      write: false,
+      control: false,
+    });
+  });
+
+  it("ignores ACL rules that apply to a different Agent Class", () => {
+    let resourceAcl = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "http://www.w3.org/ns/auth/acl#AuthenticatedAgent"
+    );
+    resourceAcl = addAclRuleQuads(
+      resourceAcl,
+      "https://arbitrary.pod/resource",
+      { read: false, append: true, write: false, control: false },
+      "resource",
+      "http://xmlns.com/foaf/0.1/Agent"
+    );
+
+    const agentAccess = unstable_getPublicResourceAccessModes(resourceAcl);
+
+    expect(agentAccess).toEqual({
+      read: false,
+      append: true,
+      write: false,
+      control: false,
+    });
+  });
+
+  it("ignores ACL rules that apply to a different Resource", () => {
+    let resourceAcl = addAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some-other.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "http://xmlns.com/foaf/0.1/Agent"
+    );
+    resourceAcl = addAclRuleQuads(
+      resourceAcl,
+      "https://some.pod/resource",
+      { read: false, append: true, write: false, control: false },
+      "resource",
+      "http://xmlns.com/foaf/0.1/Agent"
+    );
+
+    const agentAccess = unstable_getPublicResourceAccessModes(resourceAcl);
+
+    expect(agentAccess).toEqual({
+      read: false,
+      append: true,
+      write: false,
+      control: false,
+    });
+  });
+});

--- a/src/acl/agentClass.ts
+++ b/src/acl/agentClass.ts
@@ -21,6 +21,8 @@
 
 import {
   IriString,
+  WithResourceInfo,
+  unstable_WithAcl,
   unstable_AccessModes,
   unstable_AclDataset,
   unstable_AclRule,
@@ -33,7 +35,31 @@ import {
   internal_getDefaultAclRulesForResource,
   internal_getAccessModes,
   internal_combineAccessModes,
+  unstable_hasResourceAcl,
+  unstable_hasFallbackAcl,
 } from "../acl";
+
+/**
+ * Find out what Access Modes have been granted to everyone for a given Resource.
+ *
+ * Keep in mind that this function will not tell you what access specific Agents have through other ACL rules, e.g. agent- or group-specific permissions.
+ *
+ * Also, please note that this function is still experimental: its API can change in non-major releases.
+ *
+ * @param resourceInfo Information about the Resource to which the given Agent may have been granted access.
+ * @returns Which Access Modes have been granted to everyone for the given LitDataset, or `null` if it could not be determined (e.g. because the current user does not have Control Access to a given Resource or its Container).
+ */
+export function unstable_getPublicAccessModes(
+  resourceInfo: unstable_WithAcl & WithResourceInfo
+): unstable_AccessModes | null {
+  if (unstable_hasResourceAcl(resourceInfo)) {
+    return unstable_getPublicResourceAccessModes(resourceInfo.acl.resourceAcl);
+  }
+  if (unstable_hasFallbackAcl(resourceInfo)) {
+    return unstable_getPublicDefaultAccessModes(resourceInfo.acl.fallbackAcl);
+  }
+  return null;
+}
 
 /**
  * Given an ACL LitDataset, find out which access modes it provides to everyone for its associated Resource.

--- a/src/acl/agentClass.ts
+++ b/src/acl/agentClass.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {
+  IriString,
+  unstable_AccessModes,
+  unstable_AclDataset,
+  unstable_AclRule,
+} from "../interfaces";
+import { acl, foaf } from "../constants";
+import { getIriAll } from "../thing/get";
+import {
+  internal_getAclRules,
+  internal_getResourceAclRulesForResource,
+  internal_getAccessModes,
+  internal_combineAccessModes,
+} from "../acl";
+
+/**
+ * Given an ACL LitDataset, find out which access modes it provides to everyone for its associated Resource.
+ *
+ * Keep in mind that this function will not tell you:
+ * - what access specific Agents have through other ACL rules, e.g. agent- or group-specific permissions.
+ * - what access anyone has to child Resources, in case the associated Resource is a Container.
+ *
+ * Also, please note that this function is still experimental: its API can change in non-major releases.
+ *
+ * @param aclDataset The LitDataset that contains Access-Control List rules.
+ * @returns Which Access Modes have been granted to everyone for the Resource the given ACL LitDataset is associated with.
+ */
+export function unstable_getPublicResourceAccessModes(
+  aclDataset: unstable_AclDataset
+): unstable_AccessModes {
+  const allRules = internal_getAclRules(aclDataset);
+  const resourceRules = internal_getResourceAclRulesForResource(
+    allRules,
+    aclDataset.accessTo
+  );
+  const publicResourceRules = getAgentClassAclRulesForAgentClass(
+    resourceRules,
+    foaf.Agent
+  );
+  const publicAccessModes = publicResourceRules.map(internal_getAccessModes);
+  return internal_combineAccessModes(publicAccessModes);
+}
+
+function getAgentClassAclRulesForAgentClass(
+  aclRules: unstable_AclRule[],
+  agentClass: IriString
+): unstable_AclRule[] {
+  return aclRules.filter((rule) => appliesToAgentClass(rule, agentClass));
+}
+
+function appliesToAgentClass(
+  aclRule: unstable_AclRule,
+  agentClass: IriString
+): boolean {
+  return getIriAll(aclRule, acl.agentClass).includes(agentClass);
+}

--- a/src/acl/agentClass.ts
+++ b/src/acl/agentClass.ts
@@ -30,6 +30,7 @@ import { getIriAll } from "../thing/get";
 import {
   internal_getAclRules,
   internal_getResourceAclRulesForResource,
+  internal_getDefaultAclRulesForResource,
   internal_getAccessModes,
   internal_combineAccessModes,
 } from "../acl";
@@ -39,7 +40,7 @@ import {
  *
  * Keep in mind that this function will not tell you:
  * - what access specific Agents have through other ACL rules, e.g. agent- or group-specific permissions.
- * - what access anyone has to child Resources, in case the associated Resource is a Container.
+ * - what access anyone has to child Resources, in case the associated Resource is a Container (see [[unstable_getDefaultResourceAccessModes]] for that).
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
@@ -51,6 +52,34 @@ export function unstable_getPublicResourceAccessModes(
 ): unstable_AccessModes {
   const allRules = internal_getAclRules(aclDataset);
   const resourceRules = internal_getResourceAclRulesForResource(
+    allRules,
+    aclDataset.accessTo
+  );
+  const publicResourceRules = getAgentClassAclRulesForAgentClass(
+    resourceRules,
+    foaf.Agent
+  );
+  const publicAccessModes = publicResourceRules.map(internal_getAccessModes);
+  return internal_combineAccessModes(publicAccessModes);
+}
+
+/**
+ * Given an ACL LitDataset, find out which access modes it provides to everyone for the associated Container Resource's child Resources.
+ *
+ * Keep in mind that this function will not tell you:
+ * - what access specific Agents have through other ACL rules, e.g. agent- or group-specific permissions.
+ * - what access anyone has to the Container Resource itself (see [[unstable_getPublicResourceAccessModes]] for that).
+ *
+ * Also, please note that this function is still experimental: its API can change in non-major releases.
+ *
+ * @param aclDataset The LitDataset that contains Access-Control List rules for a certain Container.
+ * @returns Which Access Modes have been granted to everyone for the children of the Container associated with the given ACL LitDataset.
+ */
+export function unstable_getPublicDefaultAccessModes(
+  aclDataset: unstable_AclDataset
+): unstable_AccessModes {
+  const allRules = internal_getAclRules(aclDataset);
+  const resourceRules = internal_getDefaultAclRulesForResource(
     allRules,
     aclDataset.accessTo
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,3 +38,8 @@ export const acl = {
 export const rdf = {
   type: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
 } as const;
+
+/** @internal */
+export const foaf = {
+  Agent: "http://xmlns.com/foaf/0.1/Agent",
+} as const;

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -30,6 +30,7 @@ import {
   saveLitDatasetAt,
   unstable_fetchLitDatasetWithAcl,
   unstable_hasResourceAcl,
+  unstable_getPublicAccessModes,
   unstable_getAgentAccessModesOne,
   unstable_getFallbackAcl,
   unstable_getResourceAcl,
@@ -92,6 +93,12 @@ describe("End-to-end tests", () => {
 
     expect(unstable_hasResourceAcl(datasetWithAcl)).toBe(true);
     expect(unstable_hasResourceAcl(datasetWithoutAcl)).toBe(false);
+    expect(unstable_getPublicAccessModes(datasetWithAcl)).toEqual({
+      read: true,
+      append: true,
+      write: true,
+      control: true,
+    });
     expect(
       unstable_getAgentAccessModesOne(
         datasetWithAcl,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -101,6 +101,7 @@ import {
   unstable_getAgentDefaultAccessModesOne,
   unstable_getAgentDefaultAccessModesAll,
   unstable_setAgentDefaultAccessModes,
+  unstable_getPublicAccessModes,
   unstable_getPublicResourceAccessModes,
   unstable_getPublicDefaultAccessModes,
   // Deprecated functions still exported for backwards compatibility:
@@ -200,6 +201,7 @@ it("exports the public API from the entry file", () => {
   expect(unstable_getAgentDefaultAccessModesOne).toBeDefined();
   expect(unstable_getAgentDefaultAccessModesAll).toBeDefined();
   expect(unstable_setAgentDefaultAccessModes).toBeDefined();
+  expect(unstable_getPublicAccessModes).toBeDefined();
   expect(unstable_getPublicResourceAccessModes).toBeDefined();
   expect(unstable_getPublicDefaultAccessModes).toBeDefined();
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -101,6 +101,7 @@ import {
   unstable_getAgentDefaultAccessModesOne,
   unstable_getAgentDefaultAccessModesAll,
   unstable_setAgentDefaultAccessModes,
+  unstable_getPublicResourceAccessModes,
   // Deprecated functions still exported for backwards compatibility:
   getStringUnlocalizedOne,
   getStringUnlocalizedAll,
@@ -198,6 +199,7 @@ it("exports the public API from the entry file", () => {
   expect(unstable_getAgentDefaultAccessModesOne).toBeDefined();
   expect(unstable_getAgentDefaultAccessModesAll).toBeDefined();
   expect(unstable_setAgentDefaultAccessModes).toBeDefined();
+  expect(unstable_getPublicResourceAccessModes).toBeDefined();
 });
 
 it("still exports deprecated methods", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -102,6 +102,7 @@ import {
   unstable_getAgentDefaultAccessModesAll,
   unstable_setAgentDefaultAccessModes,
   unstable_getPublicResourceAccessModes,
+  unstable_getPublicDefaultAccessModes,
   // Deprecated functions still exported for backwards compatibility:
   getStringUnlocalizedOne,
   getStringUnlocalizedAll,
@@ -200,6 +201,7 @@ it("exports the public API from the entry file", () => {
   expect(unstable_getAgentDefaultAccessModesAll).toBeDefined();
   expect(unstable_setAgentDefaultAccessModes).toBeDefined();
   expect(unstable_getPublicResourceAccessModes).toBeDefined();
+  expect(unstable_getPublicDefaultAccessModes).toBeDefined();
 });
 
 it("still exports deprecated methods", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,6 +144,7 @@ export {
   unstable_setAgentDefaultAccessModes,
 } from "./acl/agent";
 export {
+  unstable_getPublicAccessModes,
   unstable_getPublicResourceAccessModes,
   unstable_getPublicDefaultAccessModes,
 } from "./acl/agentClass";

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,7 +143,10 @@ export {
   unstable_getAgentDefaultAccessModesAll,
   unstable_setAgentDefaultAccessModes,
 } from "./acl/agent";
-export { unstable_getPublicResourceAccessModes } from "./acl/agentClass";
+export {
+  unstable_getPublicResourceAccessModes,
+  unstable_getPublicDefaultAccessModes,
+} from "./acl/agentClass";
 export {
   Url,
   Iri,

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,6 +143,7 @@ export {
   unstable_getAgentDefaultAccessModesAll,
   unstable_setAgentDefaultAccessModes,
 } from "./acl/agent";
+export { unstable_getPublicResourceAccessModes } from "./acl/agentClass";
 export {
   Url,
   Iri,

--- a/website/docs/tutorials/managing-access.md
+++ b/website/docs/tutorials/managing-access.md
@@ -50,6 +50,29 @@ Getting access information when fetching a resource may result in an additional 
 unecessary requests, the API makes it explicit when you get access information along your resource: `unstable_fetchLitDatasetWithAcl`. The returned value includes both the Resource data (e.g. your profile or friend list), the `ResourceInfo`,
 and the ACL containing the associated access information.
 
+### Reading public access
+
+Given a [LitDataset](../glossary#litdataset) that has an ACL attached, you can check what access
+everyone has, regardless of whether they are authenticated or not. You can do so using
+[`unstable_getPublicAccessModes`](../api/modules/_acl_agentclass_#unstable_getpublicaccessmodes):
+
+```typescript
+import {
+  unstable_fetchLitDatasetWithAcl,
+  unstable_getPublicAccessModes,
+} from "@solid/lit-pod";
+
+const webId = "https://example.com/profile#webid";
+const litDatasetWithAcl = await unstable_fetchLitDatasetWithAcl(
+  "https://example.com"
+);
+const publicAccess = unstable_getPublicAccessModes(litDatasetWithAcl);
+
+// => an object like
+//    { read: true, append: false, write: false, control: true }
+//    or null if the ACL is not accessible to the current user.
+```
+
 ### Reading agent access
 
 Given a [LitDataset](../glossary#litdataset) that has an ACL attached, you can check what access a
@@ -75,7 +98,7 @@ const agentAccess = unstable_getAgentAccessModesOne(litDatasetWithAcl, webId);
 //    or null if the ACL is not accessible to the current user.
 ```
 
-To get all agent to whom access was granted, use
+To get all agents to whom access was granted, use
 [`unstable_getAgentAccessModesAll`](../api/modules/_acl_agent_#unstable_getagentaccessmodesall):
 
 ```typescript


### PR DESCRIPTION
# New feature description

This PR adds `getPublicAccessModes()`, `getPublicResourceAccessModes()` and `getPublicDefaultAccessModes()`. They're mostly similar to the respective agent-specific functions, but applying to `acl:agentClass` `foaf:Agent`, of course.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
