### PR TITLE
Add isLitDataset() function

### DIFF
--- a/src/__snapshots__/litDataset.test.ts.snap
+++ b/src/__snapshots__/litDataset.test.ts.snap
@@ -102,6 +102,7 @@ DatasetCore {
   "resourceInfo": Object {
     "contentType": "text/plain;charset=UTF-8",
     "fetchedFrom": "https://arbitrary.pod/resource",
+    "isLitDataset": false,
   },
 }
 `;

--- a/src/acl.test.ts
+++ b/src/acl.test.ts
@@ -67,6 +67,7 @@ describe("fetchResourceAcl", () => {
     const sourceDataset: WithResourceInfo = {
       resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
+        isLitDataset: true,
         unstable_aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -94,6 +95,7 @@ describe("fetchResourceAcl", () => {
     const sourceDataset: WithResourceInfo = {
       resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
+        isLitDataset: true,
         unstable_aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -115,6 +117,7 @@ describe("fetchResourceAcl", () => {
     const sourceDataset: WithResourceInfo = {
       resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
+        isLitDataset: true,
       },
     };
 
@@ -127,6 +130,7 @@ describe("fetchResourceAcl", () => {
     const sourceDataset: WithResourceInfo = {
       resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
+        isLitDataset: true,
         unstable_aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -154,6 +158,7 @@ describe("fetchFallbackAcl", () => {
     const sourceDataset = {
       resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
+        isLitDataset: true,
         // If no ACL IRI is given, the user does not have Control Access,
         // in which case we wouldn't be able to reliably determine the effective ACL.
         // Hence, the function requires the given LitDataset to have one known:
@@ -189,6 +194,7 @@ describe("fetchFallbackAcl", () => {
     const sourceDataset = {
       resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
+        isLitDataset: true,
         unstable_aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -209,6 +215,7 @@ describe("fetchFallbackAcl", () => {
     const sourceDataset = {
       resourceInfo: {
         fetchedFrom: "https://some.pod/with-acl/without-acl/resource",
+        isLitDataset: true,
         // If no ACL IRI is given, the user does not have Control Access,
         // in which case we wouldn't be able to reliably determine the effective ACL.
         // Hence, the function requires the given LitDataset to have one known:
@@ -276,6 +283,7 @@ describe("fetchFallbackAcl", () => {
       resourceInfo: {
         fetchedFrom:
           "https://some.pod/arbitrary-parent/no-control-access/resource",
+        isLitDataset: true,
         // If no ACL IRI is given, the user does not have Control Access,
         // in which case we wouldn't be able to reliably determine the effective ACL.
         // Hence, the function requires the given LitDataset to have one known:
@@ -306,6 +314,7 @@ describe("fetchFallbackAcl", () => {
     const sourceDataset = {
       resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
+        isLitDataset: true,
         // If no ACL IRI is given, the user does not have Control Access,
         // in which case we wouldn't be able to reliably determine the effective ACL.
         // Hence, the function requires the given LitDataset to have one known:
@@ -347,12 +356,16 @@ describe("getResourceAcl", () => {
   it("returns the attached Resource ACL Dataset", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
       accessTo: "https://arbitrary.pod/resource",
-      resourceInfo: { fetchedFrom: "https://arbitrary.pod/resource.acl" },
+      resourceInfo: {
+        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        isLitDataset: true,
+      },
     });
     const litDataset = Object.assign(dataset(), {
       acl: { resourceAcl: aclDataset, fallbackAcl: null },
       resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
+        isLitDataset: true,
         unstable_aclUrl: "https://arbitrary.pod/resource.acl",
       },
     });
@@ -362,12 +375,16 @@ describe("getResourceAcl", () => {
   it("returns null if the given Resource does not consider the attached ACL to pertain to it", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
       accessTo: "https://arbitrary.pod/resource",
-      resourceInfo: { fetchedFrom: "https://arbitrary.pod/resource.acl" },
+      resourceInfo: {
+        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        isLitDataset: true,
+      },
     });
     const litDataset = Object.assign(dataset(), {
       acl: { resourceAcl: aclDataset, fallbackAcl: null },
       resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
+        isLitDataset: true,
         unsafe_aclUrl: "https://arbitrary.pod/other-resource.acl",
       },
     });
@@ -377,12 +394,16 @@ describe("getResourceAcl", () => {
   it("returns null if the attached ACL does not pertain to the given Resource", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
       accessTo: "https://arbitrary.pod/other-resource",
-      resourceInfo: { fetchedFrom: "https://arbitrary.pod/resource.acl" },
+      resourceInfo: {
+        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        isLitDataset: true,
+      },
     });
     const litDataset = Object.assign(dataset(), {
       acl: { resourceAcl: aclDataset, fallbackAcl: null },
       resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
+        isLitDataset: true,
         unsafe_aclUrl: "https://arbitrary.pod/resource.acl",
       },
     });
@@ -392,7 +413,10 @@ describe("getResourceAcl", () => {
   it("returns null if the given LitDataset does not have a Resource ACL attached", () => {
     const litDataset = Object.assign(dataset(), {
       acl: { fallbackAcl: null, resourceAcl: null },
-      resourceInfo: { fetchedFrom: "https://arbitrary.pod/resource" },
+      resourceInfo: {
+        fetchedFrom: "https://arbitrary.pod/resource",
+        isLitDataset: true,
+      },
     });
     expect(unstable_getResourceAcl(litDataset)).toBeNull();
   });
@@ -402,7 +426,10 @@ describe("getFallbackAcl", () => {
   it("returns the attached Fallback ACL Dataset", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
       accessTo: "https://arbitrary.pod/",
-      resourceInfo: { fetchedFrom: "https://arbitrary.pod/.acl" },
+      resourceInfo: {
+        fetchedFrom: "https://arbitrary.pod/.acl",
+        isLitDataset: true,
+      },
     });
     const litDataset = Object.assign(dataset(), {
       acl: { fallbackAcl: aclDataset, resourceAcl: null },
@@ -421,7 +448,10 @@ describe("getFallbackAcl", () => {
 describe("getAclRules", () => {
   it("only returns Things that represent ACL Rules", () => {
     const aclDataset = Object.assign(dataset(), {
-      resourceInfo: { fetchedFrom: "https://arbitrary.pod/resource.acl" },
+      resourceInfo: {
+        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        isLitDataset: true,
+      },
       accessTo: "https://arbitrary.pod/resource",
     });
 
@@ -507,7 +537,10 @@ describe("getAclRules", () => {
 
   it("returns Things with multiple `rdf:type`s, as long as at least on type is `acl:Authorization`", () => {
     const aclDataset = Object.assign(dataset(), {
-      resourceInfo: { fetchedFrom: "https://arbitrary.pod/resource.acl" },
+      resourceInfo: {
+        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        isLitDataset: true,
+      },
       accessTo: "https://arbitrary.pod/resource",
     });
 
@@ -916,7 +949,10 @@ describe("combineAccessModes", () => {
 describe("removeEmptyAclRules", () => {
   it("removes rules that do not apply to anyone", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: { fetchedFrom: "https://arbitrary.pod/resource.acl" },
+      resourceInfo: {
+        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        isLitDataset: true,
+      },
       accessTo: "https://arbitrary.pod/resource",
     });
     const subjectIri = "https://arbitrary.pod/resource.acl#emptyRule";
@@ -951,7 +987,10 @@ describe("removeEmptyAclRules", () => {
 
   it("does not modify the input LitDataset", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: { fetchedFrom: "https://arbitrary.pod/resource.acl" },
+      resourceInfo: {
+        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        isLitDataset: true,
+      },
       accessTo: "https://arbitrary.pod/resource",
     });
     const subjectIri = "https://arbitrary.pod/resource.acl#emptyRule";
@@ -987,7 +1026,10 @@ describe("removeEmptyAclRules", () => {
 
   it("removes rules that do not set any Access Modes", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: { fetchedFrom: "https://arbitrary.pod/resource.acl" },
+      resourceInfo: {
+        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        isLitDataset: true,
+      },
       accessTo: "https://arbitrary.pod/resource",
     });
     const subjectIri = "https://arbitrary.pod/resource.acl#emptyRule";
@@ -1022,7 +1064,10 @@ describe("removeEmptyAclRules", () => {
 
   it("removes rules that do not have target Resources to which they apply", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: { fetchedFrom: "https://arbitrary.pod/resource.acl" },
+      resourceInfo: {
+        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        isLitDataset: true,
+      },
       accessTo: "https://arbitrary.pod/resource",
     });
     const subjectIri = "https://arbitrary.pod/resource.acl#emptyRule";
@@ -1057,7 +1102,10 @@ describe("removeEmptyAclRules", () => {
 
   it("removes rules that specify an acl:origin but not in combination with an Agent, Agent Group or Agent Class", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: { fetchedFrom: "https://arbitrary.pod/resource.acl" },
+      resourceInfo: {
+        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        isLitDataset: true,
+      },
       accessTo: "https://arbitrary.pod/resource",
     });
     const subjectIri = "https://arbitrary.pod/resource.acl#emptyRule";
@@ -1099,7 +1147,10 @@ describe("removeEmptyAclRules", () => {
 
   it("does not remove Rules that are also something other than an ACL Rule", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: { fetchedFrom: "https://arbitrary.pod/resource.acl" },
+      resourceInfo: {
+        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        isLitDataset: true,
+      },
       accessTo: "https://arbitrary.pod/resource",
     });
     const subjectIri = "https://arbitrary.pod/resource.acl#rule";
@@ -1150,7 +1201,10 @@ describe("removeEmptyAclRules", () => {
 
   it("does not remove Things that are Rules but also have other Quads", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: { fetchedFrom: "https://arbitrary.pod/resource.acl" },
+      resourceInfo: {
+        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        isLitDataset: true,
+      },
       accessTo: "https://arbitrary.pod/resource",
     });
     const subjectIri = "https://arbitrary.pod/resource.acl#rule";
@@ -1199,7 +1253,10 @@ describe("removeEmptyAclRules", () => {
 
   it("does not remove Rules that apply to a Container's child Resources", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: { fetchedFrom: "https://arbitrary.pod/container/.acl" },
+      resourceInfo: {
+        fetchedFrom: "https://arbitrary.pod/container/.acl",
+        isLitDataset: true,
+      },
       accessTo: "https://arbitrary.pod/container/",
     });
     const subjectIri = "https://arbitrary.pod/container/.acl#rule";
@@ -1241,7 +1298,10 @@ describe("removeEmptyAclRules", () => {
 
   it("does not remove Rules that apply to an Agent", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: { fetchedFrom: "https://arbitrary.pod/resource.acl" },
+      resourceInfo: {
+        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        isLitDataset: true,
+      },
       accessTo: "https://arbitrary.pod/resource",
     });
     const subjectIri = "https://arbitrary.pod/resource.acl#rule";
@@ -1283,7 +1343,10 @@ describe("removeEmptyAclRules", () => {
 
   it("does not remove Rules that apply to an Agent Group", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: { fetchedFrom: "https://arbitrary.pod/resource.acl" },
+      resourceInfo: {
+        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        isLitDataset: true,
+      },
       accessTo: "https://arbitrary.pod/resource",
     });
     const subjectIri = "https://arbitrary.pod/resource.acl#rule";
@@ -1325,7 +1388,10 @@ describe("removeEmptyAclRules", () => {
 
   it("does not remove Rules that apply to an Agent Class", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: { fetchedFrom: "https://arbitrary.pod/resource.acl" },
+      resourceInfo: {
+        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        isLitDataset: true,
+      },
       accessTo: "https://arbitrary.pod/resource",
     });
     const subjectIri = "https://arbitrary.pod/resource.acl#rule";

--- a/src/acl/agent.test.ts
+++ b/src/acl/agent.test.ts
@@ -140,6 +140,7 @@ function getMockDataset(fetchedFrom: IriString): LitDataset & WithResourceInfo {
   return Object.assign(dataset(), {
     resourceInfo: {
       fetchedFrom: fetchedFrom,
+      isLitDataset: true,
     },
   });
 }

--- a/src/acl/agentClass.test.ts
+++ b/src/acl/agentClass.test.ts
@@ -137,6 +137,7 @@ function getMockDataset(fetchedFrom: IriString): LitDataset & WithResourceInfo {
   return Object.assign(dataset(), {
     resourceInfo: {
       fetchedFrom: fetchedFrom,
+      isLitDataset: true,
     },
   });
 }

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -28,6 +28,8 @@ import {
   setDatetime,
   setStringNoLocale,
   saveLitDatasetAt,
+  isLitDataset,
+  unstable_fetchResourceInfoWithAcl,
   unstable_fetchLitDatasetWithAcl,
   unstable_hasResourceAcl,
   unstable_getPublicAccessModes,
@@ -77,6 +79,19 @@ describe("End-to-end tests", () => {
     );
     expect(getStringNoLocaleOne(savedThing, foaf.nick)).toBe(randomNick);
   });
+
+  it("can differentiate between RDF and non-RDF Resources", async () => {
+    const rdfResourceInfo = await unstable_fetchResourceInfoWithAcl(
+      "https://lit-e2e-test.inrupt.net/public/lit-pod-resource-info-test/litdataset.ttl"
+    );
+    const nonRdfResourceInfo = await unstable_fetchResourceInfoWithAcl(
+      "https://lit-e2e-test.inrupt.net/public/lit-pod-resource-info-test/not-a-litdataset.png"
+    );
+    expect(isLitDataset(rdfResourceInfo)).toBe(true);
+    expect(isLitDataset(nonRdfResourceInfo)).toBe(false);
+    // Fetching both Resource and Fallback ACLs takes quite a while on a bad network connection,
+    // so double Jest's default timeout of 5 seconds:
+  }, 10000);
 
   it("should be able to read and update ACLs", async () => {
     const fakeWebId =

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -28,6 +28,7 @@ import {
   fetchLitDataset,
   unstable_fetchResourceInfoWithAcl,
   isContainer,
+  isLitDataset,
   getContentType,
   saveLitDatasetAt,
   saveLitDatasetInContainer,
@@ -130,6 +131,7 @@ it("exports the public API from the entry file", () => {
   expect(fetchLitDataset).toBeDefined();
   expect(unstable_fetchResourceInfoWithAcl).toBeDefined();
   expect(isContainer).toBeDefined();
+  expect(isLitDataset).toBeDefined();
   expect(getContentType).toBeDefined();
   expect(saveLitDatasetAt).toBeDefined();
   expect(saveLitDatasetInContainer).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export {
   fetchLitDataset,
   unstable_fetchResourceInfoWithAcl,
   isContainer,
+  isLitDataset,
   getContentType,
   saveLitDatasetAt,
   saveLitDatasetInContainer,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -112,6 +112,7 @@ type unstable_WacAllow = {
 export type WithResourceInfo = {
   resourceInfo: {
     fetchedFrom: UrlString;
+    isLitDataset: boolean;
     contentType?: string;
     /**
      * The URL reported by the server as possibly containing an ACL file. Note that this file might

--- a/src/litDataset.ts
+++ b/src/litDataset.ts
@@ -182,10 +182,18 @@ export async function unstable_fetchResourceInfoWithAcl(
 export function parseResourceInfo(
   response: Response
 ): WithResourceInfo["resourceInfo"] {
+  const contentTypeParts =
+    response.headers.get("Content-Type")?.split(";") ?? [];
+  const isLitDataset =
+    contentTypeParts.length > 0 &&
+    ["text/turtle", "application/ld+json"].includes(contentTypeParts[0]);
+
   const resourceInfo: WithResourceInfo["resourceInfo"] = {
     fetchedFrom: response.url,
+    isLitDataset: isLitDataset,
     contentType: response.headers.get("Content-Type") ?? undefined,
   };
+
   const linkHeader = response.headers.get("Link");
   if (linkHeader) {
     const parsedLinks = LinkHeader.parse(linkHeader);
@@ -212,6 +220,14 @@ export function parseResourceInfo(
  */
 export function isContainer(resource: WithResourceInfo): boolean {
   return resource.resourceInfo.fetchedFrom.endsWith("/");
+}
+
+/**
+ * @param resource Resource for which to check whether it contains a LitDataset.
+ * @return Whether `resource` contains a LitDataset.
+ */
+export function isLitDataset(resource: WithResourceInfo): boolean {
+  return resource.resourceInfo.isLitDataset;
 }
 
 /**
@@ -324,7 +340,7 @@ export async function saveLitDatasetAt(
     litDataset
   )
     ? { ...litDataset.resourceInfo, fetchedFrom: url }
-    : { fetchedFrom: url };
+    : { fetchedFrom: url, isLitDataset: true };
   const storedDataset: LitDataset &
     WithChangeLog &
     WithResourceInfo = Object.assign(litDataset, {
@@ -412,6 +428,7 @@ export async function saveLitDatasetInContainer(
     .href;
   const resourceInfo: WithResourceInfo["resourceInfo"] = {
     fetchedFrom: resourceIri,
+    isLitDataset: true,
   };
   const resourceWithResourceInfo: LitDataset & WithResourceInfo = Object.assign(
     litDataset,

--- a/src/thing.test.ts
+++ b/src/thing.test.ts
@@ -629,7 +629,10 @@ describe("setThing", () => {
     const datasetWithNamedNode: LitDataset & WithResourceInfo = Object.assign(
       dataset(),
       {
-        resourceInfo: { fetchedFrom: "https://some.pod/resource" },
+        resourceInfo: {
+          fetchedFrom: "https://some.pod/resource",
+          isLitDataset: true,
+        },
       }
     );
     datasetWithNamedNode.add(oldThingQuad);
@@ -671,7 +674,10 @@ describe("setThing", () => {
     );
     const datasetWithLocalSubject: LitDataset &
       WithResourceInfo = Object.assign(dataset(), {
-      resourceInfo: { fetchedFrom: "https://some.pod/resource" },
+      resourceInfo: {
+        fetchedFrom: "https://some.pod/resource",
+        isLitDataset: true,
+      },
     });
     datasetWithLocalSubject.add(oldThingQuad);
 
@@ -968,7 +974,10 @@ describe("removeThing", () => {
     const datasetWithNamedNode: LitDataset & WithResourceInfo = Object.assign(
       dataset(),
       {
-        resourceInfo: { fetchedFrom: "https://some.pod/resource" },
+        resourceInfo: {
+          fetchedFrom: "https://some.pod/resource",
+          isLitDataset: true,
+        },
       }
     );
     datasetWithNamedNode.add(oldThingQuad);
@@ -999,7 +1008,10 @@ describe("removeThing", () => {
     const datasetWithLocalNode: LitDataset & WithResourceInfo = Object.assign(
       dataset(),
       {
-        resourceInfo: { fetchedFrom: "https://some.pod/resource" },
+        resourceInfo: {
+          fetchedFrom: "https://some.pod/resource",
+          isLitDataset: true,
+        },
       }
     );
     datasetWithLocalNode.add(thingQuad);


### PR DESCRIPTION
# New feature description

This will allow applications that explore a Pod without knowing
what type of data they might encounter to determine what fetch
method to use when they have `WithResourceInfo`.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
