### PR TITLE
Expose a Resource's Content Type

### DIFF
--- a/src/__snapshots__/litDataset.test.ts.snap
+++ b/src/__snapshots__/litDataset.test.ts.snap
@@ -100,6 +100,7 @@ DatasetCore {
     },
   },
   "resourceInfo": Object {
+    "contentType": "text/plain;charset=UTF-8",
     "fetchedFrom": "https://arbitrary.pod/resource",
   },
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -28,6 +28,7 @@ import {
   fetchLitDataset,
   unstable_fetchResourceInfoWithAcl,
   isContainer,
+  getContentType,
   saveLitDatasetAt,
   saveLitDatasetInContainer,
   unstable_saveAclFor,
@@ -129,6 +130,7 @@ it("exports the public API from the entry file", () => {
   expect(fetchLitDataset).toBeDefined();
   expect(unstable_fetchResourceInfoWithAcl).toBeDefined();
   expect(isContainer).toBeDefined();
+  expect(getContentType).toBeDefined();
   expect(saveLitDatasetAt).toBeDefined();
   expect(saveLitDatasetInContainer).toBeDefined();
   expect(unstable_saveAclFor).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export {
   fetchLitDataset,
   unstable_fetchResourceInfoWithAcl,
   isContainer,
+  getContentType,
   saveLitDatasetAt,
   saveLitDatasetInContainer,
   unstable_fetchLitDatasetWithAcl,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -112,6 +112,7 @@ type unstable_WacAllow = {
 export type WithResourceInfo = {
   resourceInfo: {
     fetchedFrom: UrlString;
+    contentType?: string;
     /**
      * The URL reported by the server as possibly containing an ACL file. Note that this file might
      * not necessarily exist, in which case the ACL of the nearest Container with an ACL applies.

--- a/src/litDataset.ts
+++ b/src/litDataset.ts
@@ -184,6 +184,7 @@ export function parseResourceInfo(
 ): WithResourceInfo["resourceInfo"] {
   const resourceInfo: WithResourceInfo["resourceInfo"] = {
     fetchedFrom: response.url,
+    contentType: response.headers.get("Content-Type") ?? undefined,
   };
   const linkHeader = response.headers.get("Link");
   if (linkHeader) {
@@ -211,6 +212,14 @@ export function parseResourceInfo(
  */
 export function isContainer(resource: WithResourceInfo): boolean {
   return resource.resourceInfo.fetchedFrom.endsWith("/");
+}
+
+/**
+ * @param resource Resource for which to determine the Content Type.
+ * @returns The Content Type, if known, or null if not known.
+ */
+export function getContentType(resource: WithResourceInfo): string | null {
+  return resource.resourceInfo.contentType ?? null;
 }
 
 /**


### PR DESCRIPTION
# New feature description

This exposes the Content-Type header to developers through the `getContentType()` function.

Together with #213 and #214, this should finally fix #163, #203.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
