### PR TITLE
Disable Vercel commenting on each Pull Request

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "github": {
+    "silent": true
+  }
+}


### PR DESCRIPTION
Since it notifies GitHub's deployment API, GitHub's own interface
already links to the relevant website preview.

Specifically, it is displayed in a PR like this:

![image](https://user-images.githubusercontent.com/4251/86236323-2ea2cb80-bb9a-11ea-8a3b-5a6800217793.png)

and like this:

![image](https://user-images.githubusercontent.com/4251/86236364-3f534180-bb9a-11ea-9112-b055497411e0.png)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
