### PR TITLE
Preserve ACL properties on cloned Datasets

### DIFF
--- a/src/acl.ts
+++ b/src/acl.ts
@@ -34,6 +34,7 @@ import {
   unstable_AccessModes,
   Thing,
   IriString,
+  LitDataset,
   unstable_WithAcl,
   unstable_WithAccessibleAcl,
   unstable_WithResourceAcl,
@@ -211,6 +212,13 @@ export function unstable_getFallbackAcl(
     return null;
   }
   return dataset.acl.fallbackAcl;
+}
+
+/** @internal */
+export function internal_isAclDataset(
+  dataset: LitDataset
+): dataset is unstable_AclDataset {
+  return typeof (dataset as unstable_AclDataset).accessTo === "string";
 }
 
 /** @internal */

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -202,6 +202,21 @@ export function hasChangelog<T extends LitDataset>(
 }
 
 /**
+ * Verify whether a given LitDataset was fetched together with its Access Control List.
+ *
+ * Note that this function is still experimental and may be removed in a future non-major release.
+ *
+ * @param dataset A [[LitDataset]] that may have its ACLs attached.
+ * @returns True if `dataset` was fetched together with its ACLs.
+ */
+export function unstable_hasAcl<T extends object>(
+  dataset: T
+): dataset is T & unstable_WithAcl {
+  const potentialAcl = dataset as T & unstable_WithAcl;
+  return typeof potentialAcl.acl === "object";
+}
+
+/**
  * If this type applies to a Resource, its Access Control List, if it exists, is accessible to the currently authenticated user.
  */
 export type unstable_WithAccessibleAcl<
@@ -216,13 +231,13 @@ export type unstable_WithAccessibleAcl<
 };
 
 /**
- * Given a [[LitDataset]], verify whether it has ACL data attached to it.
+ * Given a [[LitDataset]], verify whether its Access Control List is accessible to the current user.
  *
  * This should generally only be true for LitDatasets fetched by
  * [[unstable_fetchLitDatasetWithAcl]].
  *
  * @param dataset A [[LitDataset]].
- * @returns Whether the given `dataset` has ACL data attached to it.
+ * @returns Whether the given `dataset` has a an ACL that is accessible to the current user.
  * @internal
  */
 export function unstable_hasAccessibleAcl<Resource extends WithResourceInfo>(

--- a/src/thing.ts
+++ b/src/thing.ts
@@ -41,7 +41,11 @@ import {
   WithResourceInfo,
   hasChangelog,
   hasResourceInfo,
+  unstable_hasAcl,
+  unstable_WithAcl,
+  unstable_AclDataset,
 } from "./interfaces";
+import { internal_isAclDataset } from "./acl";
 
 /**
  * @hidden Scopes are not yet consistently used in Solid and hence not properly implemented in this library yet (the add*() and set*() functions do not respect it yet), so we're not exposing these to developers at this point in time.
@@ -219,6 +223,14 @@ function cloneLitStructs<Dataset extends LitDataset>(
     (freshDataset as LitDataset & WithResourceInfo).resourceInfo = {
       ...litDataset.resourceInfo,
     };
+  }
+  if (unstable_hasAcl(litDataset)) {
+    (freshDataset as LitDataset & unstable_WithAcl).acl = {
+      ...litDataset.acl,
+    };
+  }
+  if (internal_isAclDataset(litDataset)) {
+    (freshDataset as unstable_AclDataset).accessTo = litDataset.accessTo;
   }
 
   return freshDataset as Dataset;


### PR DESCRIPTION
<!-- When fixing a bug: -->

When we perform operations on a LitDataset, we make a copy of the original dataset, copying over not just the Quads in the Dataset, but also the properties we've attached to them.

However, there are a couple of ACL-related properties that we (alright, _I_ :stuck_out_tongue: ) forgot to copy over. This PR fixes that. (It's probably easiest to first check `thing.ts`, which has the fix, but also uses a couple of type guards that did not exist yet).

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
