### PR TITLE
Add ability to copy default ACL rules to a new ACL

### DIFF
--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -39,6 +39,11 @@ import {
   unstable_getAgentResourceAccessModesOne,
   unstable_setAgentResourceAccessModes,
   unstable_saveAclFor,
+  unstable_hasFallbackAcl,
+  unstable_hasAccessibleAcl,
+  unstable_createAclFromFallbackAcl,
+  unstable_getPublicDefaultAccessModes,
+  unstable_getPublicResourceAccessModes,
 } from "./index";
 
 describe("End-to-end tests", () => {
@@ -175,6 +180,23 @@ describe("End-to-end tests", () => {
         }
       );
       await unstable_saveAclFor(datasetWithAcl, cleanedAcl);
+    }
+  });
+
+  it("can copy default rules from the fallback ACL as Resource rules to a new ACL", async () => {
+    const dataset = await unstable_fetchLitDatasetWithAcl(
+      "https://lit-e2e-test.inrupt.net/public/lit-pod-acl-initialisation-test/resource.ttl"
+    );
+    if (
+      unstable_hasFallbackAcl(dataset) &&
+      unstable_hasAccessibleAcl(dataset) &&
+      !unstable_hasResourceAcl(dataset)
+    ) {
+      const newResourceAcl = unstable_createAclFromFallbackAcl(dataset);
+      const existingFallbackAcl = unstable_getFallbackAcl(dataset);
+      expect(unstable_getPublicDefaultAccessModes(existingFallbackAcl)).toEqual(
+        unstable_getPublicResourceAccessModes(newResourceAcl)
+      );
     }
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -96,6 +96,7 @@ import {
   unstable_getFallbackAcl,
   unstable_hasResourceAcl,
   unstable_getResourceAcl,
+  unstable_createAclFromFallbackAcl,
   unstable_getAgentAccessModesOne,
   unstable_getAgentAccessModesAll,
   unstable_getAgentResourceAccessModesOne,
@@ -107,6 +108,7 @@ import {
   unstable_getPublicAccessModes,
   unstable_getPublicResourceAccessModes,
   unstable_getPublicDefaultAccessModes,
+  unstable_hasAccessibleAcl,
   // Deprecated functions still exported for backwards compatibility:
   getStringUnlocalizedOne,
   getStringUnlocalizedAll,
@@ -199,6 +201,7 @@ it("exports the public API from the entry file", () => {
   expect(unstable_getFallbackAcl).toBeDefined();
   expect(unstable_hasResourceAcl).toBeDefined();
   expect(unstable_getResourceAcl).toBeDefined();
+  expect(unstable_createAclFromFallbackAcl).toBeDefined();
   expect(unstable_getAgentAccessModesOne).toBeDefined();
   expect(unstable_getAgentAccessModesAll).toBeDefined();
   expect(unstable_getAgentResourceAccessModesOne).toBeDefined();
@@ -210,6 +213,7 @@ it("exports the public API from the entry file", () => {
   expect(unstable_getPublicAccessModes).toBeDefined();
   expect(unstable_getPublicResourceAccessModes).toBeDefined();
   expect(unstable_getPublicDefaultAccessModes).toBeDefined();
+  expect(unstable_hasAccessibleAcl).toBeDefined();
 });
 
 it("still exports deprecated methods", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,7 @@ export {
   unstable_getFallbackAcl,
   unstable_hasResourceAcl,
   unstable_getResourceAcl,
+  unstable_createAclFromFallbackAcl,
 } from "./acl";
 export {
   unstable_AgentAccess,
@@ -164,6 +165,7 @@ export {
   LocalNode,
   WithResourceInfo,
   WithChangeLog,
+  unstable_hasAccessibleAcl,
   unstable_WithAccessibleAcl,
   unstable_WithAcl,
   unstable_WithFallbackAcl,


### PR DESCRIPTION
# New feature description

**Note:** This PR depends on #222, so it's easiest to review that first.

This adds [`createAclFromFallbackAcl()`](https://lit-pod-4aq9reg7q.vercel.app/docs/api/modules/_acl_#unstable_createaclfromfallbackacl) which, given a Resource with a fallback ACL attached, generates a new ACL with the `default` ACL Rules from the fallback ACL included as `accessTo` Rules.

This means I took a slightly different approach than we originally thought: instead of copying default Rules from one given ACL to another, it initialises a brand new ACL. The primary reason for this is that I think this aligns better with the actual use case; copying default ACL Rules to an existing ACL would only lead to unpredictable results when the existing and new Rules interact together, so you'd only use this when initialising a new ACL. Additionally, with this implementation the developer does not need to first extract the relevant ACL; it can just pass the Resource directly. (And also, `copyDefaultAclRulesFromAclToOtherAclAsResourceAclRules()` just is the worst function name ever.)

One other choice I made was in the return type: I return the newly-initialised ACL, rather than e.g. the input Dataset with the new ACL attached as Resource ACL. This aligns it with [`saveAclFor()`](https://lit-pod-4aq9reg7q.vercel.app/docs/api/modules/_litdataset_#unstable_saveaclfor), and also allows the developer to call e.g. `setAgentResourceAccessModes()` to add extra ACL Rules.

# Checklist

- [ ] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
