### PR TITLE
Remove -Modes suffix from Access-related APIs

### DIFF
--- a/src/acl.test.ts
+++ b/src/acl.test.ts
@@ -36,7 +36,7 @@ import { DataFactory } from "n3";
 import {
   internal_fetchResourceAcl,
   internal_fetchFallbackAcl,
-  internal_getAccessModes,
+  internal_getAccess,
   internal_getAclRules,
   internal_getResourceAclRules,
   internal_getDefaultAclRules,
@@ -53,7 +53,7 @@ import {
   ThingPersisted,
   unstable_AclRule,
   unstable_AclDataset,
-  unstable_AccessModes,
+  unstable_Access,
 } from "./interfaces";
 
 function mockResponse(
@@ -936,7 +936,7 @@ describe("getDefaultAclRulesForResource", () => {
   });
 });
 
-describe("getAccessModes", () => {
+describe("getAccess", () => {
   it("returns true for Access Modes that are granted", () => {
     const subject = "https://arbitrary.pod/profileDoc#webId";
 
@@ -970,7 +970,7 @@ describe("getAccessModes", () => {
       )
     );
 
-    expect(internal_getAccessModes(mockRule)).toEqual({
+    expect(internal_getAccess(mockRule)).toEqual({
       read: true,
       append: true,
       write: true,
@@ -983,7 +983,7 @@ describe("getAccessModes", () => {
 
     const mockRule = Object.assign(dataset(), { url: subject });
 
-    expect(internal_getAccessModes(mockRule)).toEqual({
+    expect(internal_getAccess(mockRule)).toEqual({
       read: false,
       append: false,
       write: false,
@@ -1003,7 +1003,7 @@ describe("getAccessModes", () => {
       )
     );
 
-    expect(internal_getAccessModes(mockRule)).toEqual({
+    expect(internal_getAccess(mockRule)).toEqual({
       read: false,
       append: true,
       write: true,
@@ -1014,7 +1014,7 @@ describe("getAccessModes", () => {
 
 describe("combineAccessModes", () => {
   it("returns true for Access Modes that are true in any of the given Access Mode sets", () => {
-    const modes: unstable_AccessModes[] = [
+    const modes: unstable_Access[] = [
       { read: false, append: false, write: false, control: false },
       { read: true, append: false, write: false, control: false },
       { read: false, append: true, write: false, control: false },
@@ -1031,7 +1031,7 @@ describe("combineAccessModes", () => {
   });
 
   it("returns false for Access Modes that are false in all of the given Access Mode sets", () => {
-    const modes: unstable_AccessModes[] = [
+    const modes: unstable_Access[] = [
       { read: false, append: false, write: false, control: false },
       { read: false, append: false, write: false, control: false },
       { read: false, append: false, write: false, control: false },
@@ -1055,7 +1055,7 @@ describe("combineAccessModes", () => {
   });
 
   it("infers Append access from Write access", () => {
-    const modes: unstable_AccessModes[] = [
+    const modes: unstable_Access[] = [
       { read: false, append: false, write: false, control: false },
       { read: false, append: false, write: true, control: false } as any,
     ];

--- a/src/acl.ts
+++ b/src/acl.ts
@@ -31,7 +31,7 @@ import {
   unstable_AclDataset,
   unstable_hasAccessibleAcl,
   unstable_AclRule,
-  unstable_AccessModes,
+  unstable_Access,
   Thing,
   IriString,
   LitDataset,
@@ -327,9 +327,7 @@ function isDefaultForResource(
 }
 
 /** @internal */
-export function internal_getAccessModes(
-  rule: unstable_AclRule
-): unstable_AccessModes {
+export function internal_getAccess(rule: unstable_AclRule): unstable_Access {
   const ruleAccessModes = getIriAll(rule, acl.mode);
   const writeAccess = ruleAccessModes.includes(
     internal_accessModeIriStrings.write
@@ -355,8 +353,8 @@ export function internal_getAccessModes(
 
 /** @internal */
 export function internal_combineAccessModes(
-  modes: unstable_AccessModes[]
-): unstable_AccessModes {
+  modes: unstable_Access[]
+): unstable_Access {
   return modes.reduce(
     (accumulator, current) => {
       const writeAccess = accumulator.write || current.write;

--- a/src/acl/agent.test.ts
+++ b/src/acl/agent.test.ts
@@ -24,18 +24,18 @@ import { Quad } from "rdf-js";
 import { dataset } from "@rdfjs/dataset";
 import { DataFactory } from "n3";
 import {
-  unstable_getAgentResourceAccessModesOne,
-  unstable_getAgentResourceAccessModesAll,
-  unstable_getAgentDefaultAccessModesOne,
-  unstable_getAgentDefaultAccessModesAll,
-  unstable_setAgentResourceAccessModes,
-  unstable_getAgentAccessModesOne,
-  unstable_getAgentAccessModesAll,
-  unstable_setAgentDefaultAccessModes,
+  unstable_getAgentResourceAccessOne,
+  unstable_getAgentResourceAccessAll,
+  unstable_getAgentDefaultAccessOne,
+  unstable_getAgentDefaultAccessAll,
+  unstable_setAgentResourceAccess,
+  unstable_getAgentAccessOne,
+  unstable_getAgentAccessAll,
+  unstable_setAgentDefaultAccess,
 } from "./agent";
 import {
   LitDataset,
-  unstable_AccessModes,
+  unstable_Access,
   unstable_WithAcl,
   WithResourceInfo,
   IriString,
@@ -46,7 +46,7 @@ function addAclRuleQuads(
   aclDataset: LitDataset & WithResourceInfo,
   agent: IriString,
   resource: IriString,
-  accessModes: unstable_AccessModes,
+  access: unstable_Access,
   type: "resource" | "default"
 ): unstable_AclDataset {
   const subjectIri = resource + "#" + encodeURIComponent(agent) + Math.random();
@@ -75,7 +75,7 @@ function addAclRuleQuads(
       DataFactory.namedNode(agent)
     )
   );
-  if (accessModes.read) {
+  if (access.read) {
     aclDataset.add(
       DataFactory.quad(
         DataFactory.namedNode(subjectIri),
@@ -84,7 +84,7 @@ function addAclRuleQuads(
       )
     );
   }
-  if (accessModes.append) {
+  if (access.append) {
     aclDataset.add(
       DataFactory.quad(
         DataFactory.namedNode(subjectIri),
@@ -93,7 +93,7 @@ function addAclRuleQuads(
       )
     );
   }
-  if (accessModes.write) {
+  if (access.write) {
     aclDataset.add(
       DataFactory.quad(
         DataFactory.namedNode(subjectIri),
@@ -102,7 +102,7 @@ function addAclRuleQuads(
       )
     );
   }
-  if (accessModes.control) {
+  if (access.control) {
     aclDataset.add(
       DataFactory.quad(
         DataFactory.namedNode(subjectIri),
@@ -145,7 +145,7 @@ function getMockDataset(fetchedFrom: IriString): LitDataset & WithResourceInfo {
   });
 }
 
-describe("getAgentAccessModesOne", () => {
+describe("getAgentAccessOne", () => {
   it("returns the Resource's own applicable ACL rules", () => {
     const litDataset = getMockDataset("https://some.pod/container/resource");
     const resourceAcl = addAclRuleQuads(
@@ -161,12 +161,12 @@ describe("getAgentAccessModesOne", () => {
       "resource"
     );
 
-    const accessModes = unstable_getAgentAccessModesOne(
+    const access = unstable_getAgentAccessOne(
       litDatasetWithAcl,
       "https://some.pod/profileDoc#webId"
     );
 
-    expect(accessModes).toEqual({
+    expect(access).toEqual({
       read: false,
       append: false,
       write: false,
@@ -189,12 +189,12 @@ describe("getAgentAccessModesOne", () => {
       "fallback"
     );
 
-    const accessModes = unstable_getAgentAccessModesOne(
+    const access = unstable_getAgentAccessOne(
       litDatasetWithAcl,
       "https://some.pod/profileDoc#webId"
     );
 
-    expect(accessModes).toEqual({
+    expect(access).toEqual({
       read: false,
       append: false,
       write: false,
@@ -213,7 +213,7 @@ describe("getAgentAccessModesOne", () => {
     );
 
     expect(
-      unstable_getAgentAccessModesOne(
+      unstable_getAgentAccessOne(
         litDatasetWithInaccessibleAcl,
         "https://arbitrary.pod/profileDoc#webId"
       )
@@ -247,12 +247,12 @@ describe("getAgentAccessModesOne", () => {
       "fallback"
     );
 
-    const accessModes = unstable_getAgentAccessModesOne(
+    const access = unstable_getAgentAccessOne(
       litDatasetWithAcl,
       "https://some.pod/profileDoc#webId"
     );
 
-    expect(accessModes).toEqual({
+    expect(access).toEqual({
       read: true,
       append: false,
       write: false,
@@ -282,12 +282,12 @@ describe("getAgentAccessModesOne", () => {
       "resource"
     );
 
-    const accessModes = unstable_getAgentAccessModesOne(
+    const access = unstable_getAgentAccessOne(
       litDatasetWithAcl,
       "https://some.pod/profileDoc#webId"
     );
 
-    expect(accessModes).toEqual({
+    expect(access).toEqual({
       read: true,
       append: false,
       write: false,
@@ -317,12 +317,12 @@ describe("getAgentAccessModesOne", () => {
       "fallback"
     );
 
-    const accessModes = unstable_getAgentAccessModesOne(
+    const access = unstable_getAgentAccessOne(
       litDatasetWithAcl,
       "https://some.pod/profileDoc#webId"
     );
 
-    expect(accessModes).toEqual({
+    expect(access).toEqual({
       read: false,
       append: false,
       write: false,
@@ -331,7 +331,7 @@ describe("getAgentAccessModesOne", () => {
   });
 });
 
-describe("getAgentAccessModesAll", () => {
+describe("getAgentAccessAll", () => {
   it("returns the Resource's own applicable ACL rules, grouped by Agent", () => {
     const litDataset = getMockDataset("https://some.pod/container/resource");
     const resourceAcl = addAclRuleQuads(
@@ -347,9 +347,9 @@ describe("getAgentAccessModesAll", () => {
       "resource"
     );
 
-    const accessModes = unstable_getAgentAccessModesAll(litDatasetWithAcl);
+    const access = unstable_getAgentAccessAll(litDatasetWithAcl);
 
-    expect(accessModes).toEqual({
+    expect(access).toEqual({
       "https://some.pod/profileDoc#webId": {
         read: false,
         append: false,
@@ -374,9 +374,9 @@ describe("getAgentAccessModesAll", () => {
       "fallback"
     );
 
-    const accessModes = unstable_getAgentAccessModesAll(litDatasetWithAcl);
+    const access = unstable_getAgentAccessAll(litDatasetWithAcl);
 
-    expect(accessModes).toEqual({
+    expect(access).toEqual({
       "https://some.pod/profileDoc#webId": {
         read: false,
         append: false,
@@ -397,7 +397,7 @@ describe("getAgentAccessModesAll", () => {
     );
 
     expect(
-      unstable_getAgentAccessModesAll(litDatasetWithInaccessibleAcl)
+      unstable_getAgentAccessAll(litDatasetWithInaccessibleAcl)
     ).toBeNull();
   });
 
@@ -428,9 +428,9 @@ describe("getAgentAccessModesAll", () => {
       "fallback"
     );
 
-    const accessModes = unstable_getAgentAccessModesAll(litDatasetWithAcl);
+    const access = unstable_getAgentAccessAll(litDatasetWithAcl);
 
-    expect(accessModes).toEqual({
+    expect(access).toEqual({
       "https://some.pod/profileDoc#webId": {
         read: true,
         append: false,
@@ -467,11 +467,11 @@ describe("getAgentAccessModesAll", () => {
       "fallback"
     );
 
-    const accessModes = unstable_getAgentAccessModesAll(litDatasetWithAcl);
+    const access = unstable_getAgentAccessAll(litDatasetWithAcl);
 
     // It only includes rules for agent "https://some.pod/profileDoc#webId",
     // not for "https://some-other.pod/profileDoc#webId"
-    expect(accessModes).toEqual({
+    expect(access).toEqual({
       "https://some.pod/profileDoc#webId": {
         read: true,
         append: false,
@@ -503,9 +503,9 @@ describe("getAgentAccessModesAll", () => {
       "resource"
     );
 
-    const accessModes = unstable_getAgentAccessModesAll(litDatasetWithAcl);
+    const access = unstable_getAgentAccessAll(litDatasetWithAcl);
 
-    expect(accessModes).toEqual({
+    expect(access).toEqual({
       "https://some.pod/profileDoc#webId": {
         read: true,
         append: false,
@@ -537,9 +537,9 @@ describe("getAgentAccessModesAll", () => {
       "fallback"
     );
 
-    const accessModes = unstable_getAgentAccessModesAll(litDatasetWithAcl);
+    const access = unstable_getAgentAccessAll(litDatasetWithAcl);
 
-    expect(accessModes).toEqual({
+    expect(access).toEqual({
       "https://some.pod/profileDoc#webId": {
         read: false,
         append: false,
@@ -550,7 +550,7 @@ describe("getAgentAccessModesAll", () => {
   });
 });
 
-describe("getAgentResourceAccessModesOne", () => {
+describe("getAgentResourceAccessOne", () => {
   it("returns the applicable Access Modes for a single Agent", () => {
     const resourceAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
@@ -560,7 +560,7 @@ describe("getAgentResourceAccessModesOne", () => {
       "resource"
     );
 
-    const agentAccess = unstable_getAgentResourceAccessModesOne(
+    const agentAccess = unstable_getAgentResourceAccessOne(
       resourceAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -589,7 +589,7 @@ describe("getAgentResourceAccessModesOne", () => {
       "resource"
     );
 
-    const agentAccess = unstable_getAgentResourceAccessModesOne(
+    const agentAccess = unstable_getAgentResourceAccessOne(
       resourceAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -611,7 +611,7 @@ describe("getAgentResourceAccessModesOne", () => {
       "resource"
     );
 
-    const agentAccess = unstable_getAgentResourceAccessModesOne(
+    const agentAccess = unstable_getAgentResourceAccessOne(
       resourceAcl,
       "https://some-other.pod/profileDoc#webId"
     );
@@ -640,7 +640,7 @@ describe("getAgentResourceAccessModesOne", () => {
       "resource"
     );
 
-    const agentAccess = unstable_getAgentResourceAccessModesOne(
+    const agentAccess = unstable_getAgentResourceAccessOne(
       resourceAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -669,7 +669,7 @@ describe("getAgentResourceAccessModesOne", () => {
       "resource"
     );
 
-    const agentAccess = unstable_getAgentResourceAccessModesOne(
+    const agentAccess = unstable_getAgentResourceAccessOne(
       resourceAcl,
       "https://arbitrary.pod/profileDoc#webId"
     );
@@ -683,7 +683,7 @@ describe("getAgentResourceAccessModesOne", () => {
   });
 });
 
-describe("getAgentResourceAccessModesAll", () => {
+describe("getAgentResourceAccessAll", () => {
   it("returns the applicable Access Modes for all Agents for whom Access Modes have been defined", () => {
     let resourceAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
@@ -700,7 +700,7 @@ describe("getAgentResourceAccessModesAll", () => {
       "resource"
     );
 
-    const agentAccess = unstable_getAgentResourceAccessModesAll(resourceAcl);
+    const agentAccess = unstable_getAgentResourceAccessAll(resourceAcl);
 
     expect(agentAccess).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -734,7 +734,7 @@ describe("getAgentResourceAccessModesAll", () => {
       "resource"
     );
 
-    const agentAccess = unstable_getAgentResourceAccessModesAll(resourceAcl);
+    const agentAccess = unstable_getAgentResourceAccessAll(resourceAcl);
 
     expect(agentAccess).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -763,7 +763,7 @@ describe("getAgentResourceAccessModesAll", () => {
       )
     );
 
-    const agentAccess = unstable_getAgentResourceAccessModesAll(resourceAcl);
+    const agentAccess = unstable_getAgentResourceAccessAll(resourceAcl);
 
     expect(agentAccess).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -814,7 +814,7 @@ describe("getAgentResourceAccessModesAll", () => {
       )
     );
 
-    const agentAccess = unstable_getAgentResourceAccessModesAll(resourceAcl);
+    const agentAccess = unstable_getAgentResourceAccessAll(resourceAcl);
 
     expect(agentAccess).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -842,7 +842,7 @@ describe("getAgentResourceAccessModesAll", () => {
       "resource"
     );
 
-    const agentAccess = unstable_getAgentResourceAccessModesAll(resourceAcl);
+    const agentAccess = unstable_getAgentResourceAccessAll(resourceAcl);
 
     expect(agentAccess).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -855,14 +855,14 @@ describe("getAgentResourceAccessModesAll", () => {
   });
 });
 
-describe("setAgentResourceAccessModes", () => {
+describe("setAgentResourceAccess", () => {
   it("adds Quads for the appropriate Access Modes", () => {
     const sourceDataset = Object.assign(
       getMockDataset("https://arbitrary.pod/resource.acl"),
       { accessTo: "https://arbitrary.pod/resource" }
     );
 
-    const updatedDataset = unstable_setAgentResourceAccessModes(
+    const updatedDataset = unstable_setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -917,7 +917,7 @@ describe("setAgentResourceAccessModes", () => {
       { accessTo: "https://arbitrary.pod/resource" }
     );
 
-    unstable_setAgentResourceAccessModes(
+    unstable_setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -937,7 +937,7 @@ describe("setAgentResourceAccessModes", () => {
       { accessTo: "https://arbitrary.pod/resource" }
     );
 
-    const updatedDataset = unstable_setAgentResourceAccessModes(
+    const updatedDataset = unstable_setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -985,7 +985,7 @@ describe("setAgentResourceAccessModes", () => {
       { accessTo: "https://arbitrary.pod/resource" }
     );
 
-    const updatedDataset = unstable_setAgentResourceAccessModes(
+    const updatedDataset = unstable_setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1031,7 +1031,7 @@ describe("setAgentResourceAccessModes", () => {
       "resource"
     );
 
-    const updatedDataset = unstable_setAgentResourceAccessModes(
+    const updatedDataset = unstable_setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1077,7 +1077,7 @@ describe("setAgentResourceAccessModes", () => {
       "resource"
     );
 
-    const updatedDataset = unstable_setAgentResourceAccessModes(
+    const updatedDataset = unstable_setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1109,7 +1109,7 @@ describe("setAgentResourceAccessModes", () => {
       )
     );
 
-    const updatedDataset = unstable_setAgentResourceAccessModes(
+    const updatedDataset = unstable_setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1165,7 +1165,7 @@ describe("setAgentResourceAccessModes", () => {
       )
     );
 
-    const updatedDataset = unstable_setAgentResourceAccessModes(
+    const updatedDataset = unstable_setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1221,7 +1221,7 @@ describe("setAgentResourceAccessModes", () => {
       )
     );
 
-    const updatedDataset = unstable_setAgentResourceAccessModes(
+    const updatedDataset = unstable_setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1275,7 +1275,7 @@ describe("setAgentResourceAccessModes", () => {
       )
     );
 
-    const updatedDataset = unstable_setAgentResourceAccessModes(
+    const updatedDataset = unstable_setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1329,7 +1329,7 @@ describe("setAgentResourceAccessModes", () => {
       )
     );
 
-    const updatedDataset = unstable_setAgentResourceAccessModes(
+    const updatedDataset = unstable_setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1391,7 +1391,7 @@ describe("setAgentResourceAccessModes", () => {
   });
 });
 
-describe("getAgentDefaultAccessModesOne", () => {
+describe("getAgentDefaultAccessOne", () => {
   it("returns the applicable Access Modes for a single Agent", () => {
     const containerAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
@@ -1401,7 +1401,7 @@ describe("getAgentDefaultAccessModesOne", () => {
       "default"
     );
 
-    const agentAccess = unstable_getAgentDefaultAccessModesOne(
+    const agentAccess = unstable_getAgentDefaultAccessOne(
       containerAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -1430,7 +1430,7 @@ describe("getAgentDefaultAccessModesOne", () => {
       "default"
     );
 
-    const agentAccess = unstable_getAgentDefaultAccessModesOne(
+    const agentAccess = unstable_getAgentDefaultAccessOne(
       containerAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -1452,7 +1452,7 @@ describe("getAgentDefaultAccessModesOne", () => {
       "default"
     );
 
-    const agentAccess = unstable_getAgentDefaultAccessModesOne(
+    const agentAccess = unstable_getAgentDefaultAccessOne(
       containerAcl,
       "https://some-other.pod/profileDoc#webId"
     );
@@ -1481,7 +1481,7 @@ describe("getAgentDefaultAccessModesOne", () => {
       "default"
     );
 
-    const agentAccess = unstable_getAgentDefaultAccessModesOne(
+    const agentAccess = unstable_getAgentDefaultAccessOne(
       containerAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -1510,7 +1510,7 @@ describe("getAgentDefaultAccessModesOne", () => {
       "default"
     );
 
-    const agentAccess = unstable_getAgentDefaultAccessModesOne(
+    const agentAccess = unstable_getAgentDefaultAccessOne(
       containerAcl,
       "https://arbitrary.pod/profileDoc#webId"
     );
@@ -1524,7 +1524,7 @@ describe("getAgentDefaultAccessModesOne", () => {
   });
 });
 
-describe("getAgentDefaultAccessModesAll", () => {
+describe("getAgentDefaultAccessAll", () => {
   it("returns the applicable Access Modes for all Agents for whom Access Modes have been defined", () => {
     let containerAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
@@ -1541,7 +1541,7 @@ describe("getAgentDefaultAccessModesAll", () => {
       "default"
     );
 
-    const agentAccess = unstable_getAgentDefaultAccessModesAll(containerAcl);
+    const agentAccess = unstable_getAgentDefaultAccessAll(containerAcl);
 
     expect(agentAccess).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -1575,7 +1575,7 @@ describe("getAgentDefaultAccessModesAll", () => {
       "default"
     );
 
-    const agentAccess = unstable_getAgentDefaultAccessModesAll(containerAcl);
+    const agentAccess = unstable_getAgentDefaultAccessAll(containerAcl);
 
     expect(agentAccess).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -1604,7 +1604,7 @@ describe("getAgentDefaultAccessModesAll", () => {
       )
     );
 
-    const agentAccess = unstable_getAgentDefaultAccessModesAll(containerAcl);
+    const agentAccess = unstable_getAgentDefaultAccessAll(containerAcl);
 
     expect(agentAccess).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -1655,7 +1655,7 @@ describe("getAgentDefaultAccessModesAll", () => {
       )
     );
 
-    const agentAccess = unstable_getAgentDefaultAccessModesAll(containerAcl);
+    const agentAccess = unstable_getAgentDefaultAccessAll(containerAcl);
 
     expect(agentAccess).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -1683,7 +1683,7 @@ describe("getAgentDefaultAccessModesAll", () => {
       "default"
     );
 
-    const agentAccess = unstable_getAgentDefaultAccessModesAll(containerAcl);
+    const agentAccess = unstable_getAgentDefaultAccessAll(containerAcl);
 
     expect(agentAccess).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -1696,14 +1696,14 @@ describe("getAgentDefaultAccessModesAll", () => {
   });
 });
 
-describe("setAgentDefaultAccessModes", () => {
+describe("setAgentDefaultAccess", () => {
   it("adds Quads for the appropriate Access Modes", () => {
     const sourceDataset = Object.assign(
       getMockDataset("https://arbitrary.pod/container/.acl"),
       { accessTo: "https://arbitrary.pod/container/" }
     );
 
-    const updatedDataset = unstable_setAgentDefaultAccessModes(
+    const updatedDataset = unstable_setAgentDefaultAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1760,7 +1760,7 @@ describe("setAgentDefaultAccessModes", () => {
       { accessTo: "https://arbitrary.pod/container/" }
     );
 
-    unstable_setAgentDefaultAccessModes(
+    unstable_setAgentDefaultAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1780,7 +1780,7 @@ describe("setAgentDefaultAccessModes", () => {
       { accessTo: "https://arbitrary.pod/container/" }
     );
 
-    const updatedDataset = unstable_setAgentDefaultAccessModes(
+    const updatedDataset = unstable_setAgentDefaultAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1828,7 +1828,7 @@ describe("setAgentDefaultAccessModes", () => {
       { accessTo: "https://arbitrary.pod/container/" }
     );
 
-    const updatedDataset = unstable_setAgentDefaultAccessModes(
+    const updatedDataset = unstable_setAgentDefaultAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1876,7 +1876,7 @@ describe("setAgentDefaultAccessModes", () => {
       "default"
     );
 
-    const updatedDataset = unstable_setAgentDefaultAccessModes(
+    const updatedDataset = unstable_setAgentDefaultAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1924,7 +1924,7 @@ describe("setAgentDefaultAccessModes", () => {
       "default"
     );
 
-    const updatedDataset = unstable_setAgentDefaultAccessModes(
+    const updatedDataset = unstable_setAgentDefaultAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1956,7 +1956,7 @@ describe("setAgentDefaultAccessModes", () => {
       )
     );
 
-    const updatedDataset = unstable_setAgentDefaultAccessModes(
+    const updatedDataset = unstable_setAgentDefaultAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -2012,7 +2012,7 @@ describe("setAgentDefaultAccessModes", () => {
       )
     );
 
-    const updatedDataset = unstable_setAgentDefaultAccessModes(
+    const updatedDataset = unstable_setAgentDefaultAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -2068,7 +2068,7 @@ describe("setAgentDefaultAccessModes", () => {
       )
     );
 
-    const updatedDataset = unstable_setAgentDefaultAccessModes(
+    const updatedDataset = unstable_setAgentDefaultAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -2124,7 +2124,7 @@ describe("setAgentDefaultAccessModes", () => {
       )
     );
 
-    const updatedDataset = unstable_setAgentDefaultAccessModes(
+    const updatedDataset = unstable_setAgentDefaultAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -2180,7 +2180,7 @@ describe("setAgentDefaultAccessModes", () => {
       )
     );
 
-    const updatedDataset = unstable_setAgentDefaultAccessModes(
+    const updatedDataset = unstable_setAgentDefaultAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {

--- a/src/acl/agentClass.test.ts
+++ b/src/acl/agentClass.test.ts
@@ -23,15 +23,15 @@ import { describe, it, expect } from "@jest/globals";
 import { DataFactory } from "n3";
 import { dataset } from "@rdfjs/dataset";
 import {
-  unstable_getPublicResourceAccessModes,
-  unstable_getPublicDefaultAccessModes,
-  unstable_getPublicAccessModes,
+  unstable_getPublicResourceAccess,
+  unstable_getPublicDefaultAccess,
+  unstable_getPublicAccess,
 } from "./agentClass";
 import {
   LitDataset,
   WithResourceInfo,
   IriString,
-  unstable_AccessModes,
+  unstable_Access,
   unstable_AclDataset,
   unstable_WithAcl,
 } from "../interfaces";
@@ -39,7 +39,7 @@ import {
 function addAclRuleQuads(
   aclDataset: LitDataset & WithResourceInfo,
   resource: IriString,
-  accessModes: unstable_AccessModes,
+  access: unstable_Access,
   type: "resource" | "default",
   agentClass:
     | "http://xmlns.com/foaf/0.1/Agent"
@@ -72,7 +72,7 @@ function addAclRuleQuads(
       DataFactory.namedNode(agentClass)
     )
   );
-  if (accessModes.read) {
+  if (access.read) {
     aclDataset.add(
       DataFactory.quad(
         DataFactory.namedNode(subjectIri),
@@ -81,7 +81,7 @@ function addAclRuleQuads(
       )
     );
   }
-  if (accessModes.append) {
+  if (access.append) {
     aclDataset.add(
       DataFactory.quad(
         DataFactory.namedNode(subjectIri),
@@ -90,7 +90,7 @@ function addAclRuleQuads(
       )
     );
   }
-  if (accessModes.write) {
+  if (access.write) {
     aclDataset.add(
       DataFactory.quad(
         DataFactory.namedNode(subjectIri),
@@ -99,7 +99,7 @@ function addAclRuleQuads(
       )
     );
   }
-  if (accessModes.control) {
+  if (access.control) {
     aclDataset.add(
       DataFactory.quad(
         DataFactory.namedNode(subjectIri),
@@ -142,7 +142,7 @@ function getMockDataset(fetchedFrom: IriString): LitDataset & WithResourceInfo {
   });
 }
 
-describe("getPublicAccessModes", () => {
+describe("getPublicAccess", () => {
   it("returns the Resource's own applicable ACL rules", () => {
     const litDataset = getMockDataset("https://some.pod/container/resource");
     const resourceAcl = addAclRuleQuads(
@@ -158,9 +158,9 @@ describe("getPublicAccessModes", () => {
       "resource"
     );
 
-    const accessModes = unstable_getPublicAccessModes(litDatasetWithAcl);
+    const access = unstable_getPublicAccess(litDatasetWithAcl);
 
-    expect(accessModes).toEqual({
+    expect(access).toEqual({
       read: false,
       append: false,
       write: false,
@@ -183,9 +183,9 @@ describe("getPublicAccessModes", () => {
       "fallback"
     );
 
-    const accessModes = unstable_getPublicAccessModes(litDatasetWithAcl);
+    const access = unstable_getPublicAccess(litDatasetWithAcl);
 
-    expect(accessModes).toEqual({
+    expect(access).toEqual({
       read: false,
       append: false,
       write: false,
@@ -203,9 +203,7 @@ describe("getPublicAccessModes", () => {
       inaccessibleAcl
     );
 
-    expect(
-      unstable_getPublicAccessModes(litDatasetWithInaccessibleAcl)
-    ).toBeNull();
+    expect(unstable_getPublicAccess(litDatasetWithInaccessibleAcl)).toBeNull();
   });
 
   it("ignores the fallback ACL rules if a Resource ACL LitDataset is available", () => {
@@ -235,9 +233,9 @@ describe("getPublicAccessModes", () => {
       "fallback"
     );
 
-    const accessModes = unstable_getPublicAccessModes(litDatasetWithAcl);
+    const access = unstable_getPublicAccess(litDatasetWithAcl);
 
-    expect(accessModes).toEqual({
+    expect(access).toEqual({
       read: true,
       append: false,
       write: false,
@@ -267,9 +265,9 @@ describe("getPublicAccessModes", () => {
       "resource"
     );
 
-    const accessModes = unstable_getPublicAccessModes(litDatasetWithAcl);
+    const access = unstable_getPublicAccess(litDatasetWithAcl);
 
-    expect(accessModes).toEqual({
+    expect(access).toEqual({
       read: true,
       append: false,
       write: false,
@@ -299,9 +297,9 @@ describe("getPublicAccessModes", () => {
       "fallback"
     );
 
-    const accessModes = unstable_getPublicAccessModes(litDatasetWithAcl);
+    const access = unstable_getPublicAccess(litDatasetWithAcl);
 
-    expect(accessModes).toEqual({
+    expect(access).toEqual({
       read: false,
       append: false,
       write: false,
@@ -310,7 +308,7 @@ describe("getPublicAccessModes", () => {
   });
 });
 
-describe("getPublicResourceAccessModes", () => {
+describe("getPublicResourceAccess", () => {
   it("returns the applicable Access Modes for the Agent Class foaf:Agent", () => {
     const resourceAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
@@ -320,7 +318,7 @@ describe("getPublicResourceAccessModes", () => {
       "http://xmlns.com/foaf/0.1/Agent"
     );
 
-    const publicAccess = unstable_getPublicResourceAccessModes(resourceAcl);
+    const publicAccess = unstable_getPublicResourceAccess(resourceAcl);
 
     expect(publicAccess).toEqual({
       read: true,
@@ -346,7 +344,7 @@ describe("getPublicResourceAccessModes", () => {
       "http://xmlns.com/foaf/0.1/Agent"
     );
 
-    const agentAccess = unstable_getPublicResourceAccessModes(resourceAcl);
+    const agentAccess = unstable_getPublicResourceAccess(resourceAcl);
 
     expect(agentAccess).toEqual({
       read: true,
@@ -365,7 +363,7 @@ describe("getPublicResourceAccessModes", () => {
       "http://www.w3.org/ns/auth/acl#AuthenticatedAgent"
     );
 
-    const agentAccess = unstable_getPublicResourceAccessModes(resourceAcl);
+    const agentAccess = unstable_getPublicResourceAccess(resourceAcl);
 
     expect(agentAccess).toEqual({
       read: false,
@@ -391,7 +389,7 @@ describe("getPublicResourceAccessModes", () => {
       "http://xmlns.com/foaf/0.1/Agent"
     );
 
-    const agentAccess = unstable_getPublicResourceAccessModes(resourceAcl);
+    const agentAccess = unstable_getPublicResourceAccess(resourceAcl);
 
     expect(agentAccess).toEqual({
       read: false,
@@ -417,7 +415,7 @@ describe("getPublicResourceAccessModes", () => {
       "http://xmlns.com/foaf/0.1/Agent"
     );
 
-    const agentAccess = unstable_getPublicResourceAccessModes(resourceAcl);
+    const agentAccess = unstable_getPublicResourceAccess(resourceAcl);
 
     expect(agentAccess).toEqual({
       read: false,
@@ -428,7 +426,7 @@ describe("getPublicResourceAccessModes", () => {
   });
 });
 
-describe("getPublicDefaultAccessModes", () => {
+describe("getPublicDefaultAccess", () => {
   it("returns the applicable Access Modes for the Agent Class foaf:Agent", () => {
     const containerAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
@@ -438,7 +436,7 @@ describe("getPublicDefaultAccessModes", () => {
       "http://xmlns.com/foaf/0.1/Agent"
     );
 
-    const agentAccess = unstable_getPublicDefaultAccessModes(containerAcl);
+    const agentAccess = unstable_getPublicDefaultAccess(containerAcl);
 
     expect(agentAccess).toEqual({
       read: true,
@@ -464,7 +462,7 @@ describe("getPublicDefaultAccessModes", () => {
       "http://xmlns.com/foaf/0.1/Agent"
     );
 
-    const agentAccess = unstable_getPublicDefaultAccessModes(containerAcl);
+    const agentAccess = unstable_getPublicDefaultAccess(containerAcl);
 
     expect(agentAccess).toEqual({
       read: true,
@@ -483,7 +481,7 @@ describe("getPublicDefaultAccessModes", () => {
       "http://www.w3.org/ns/auth/acl#AuthenticatedAgent"
     );
 
-    const agentAccess = unstable_getPublicDefaultAccessModes(containerAcl);
+    const agentAccess = unstable_getPublicDefaultAccess(containerAcl);
 
     expect(agentAccess).toEqual({
       read: false,
@@ -509,7 +507,7 @@ describe("getPublicDefaultAccessModes", () => {
       "http://xmlns.com/foaf/0.1/Agent"
     );
 
-    const agentAccess = unstable_getPublicDefaultAccessModes(containerAcl);
+    const agentAccess = unstable_getPublicDefaultAccess(containerAcl);
 
     expect(agentAccess).toEqual({
       read: false,
@@ -535,7 +533,7 @@ describe("getPublicDefaultAccessModes", () => {
       "http://xmlns.com/foaf/0.1/Agent"
     );
 
-    const agentAccess = unstable_getPublicDefaultAccessModes(containerAcl);
+    const agentAccess = unstable_getPublicDefaultAccess(containerAcl);
 
     expect(agentAccess).toEqual({
       read: false,

--- a/src/acl/agentClass.ts
+++ b/src/acl/agentClass.ts
@@ -23,7 +23,7 @@ import {
   IriString,
   WithResourceInfo,
   unstable_WithAcl,
-  unstable_AccessModes,
+  unstable_Access,
   unstable_AclDataset,
   unstable_AclRule,
 } from "../interfaces";
@@ -33,7 +33,7 @@ import {
   internal_getAclRules,
   internal_getResourceAclRulesForResource,
   internal_getDefaultAclRulesForResource,
-  internal_getAccessModes,
+  internal_getAccess,
   internal_combineAccessModes,
   unstable_hasResourceAcl,
   unstable_hasFallbackAcl,
@@ -49,14 +49,14 @@ import {
  * @param resourceInfo Information about the Resource to which the given Agent may have been granted access.
  * @returns Which Access Modes have been granted to everyone for the given LitDataset, or `null` if it could not be determined (e.g. because the current user does not have Control Access to a given Resource or its Container).
  */
-export function unstable_getPublicAccessModes(
+export function unstable_getPublicAccess(
   resourceInfo: unstable_WithAcl & WithResourceInfo
-): unstable_AccessModes | null {
+): unstable_Access | null {
   if (unstable_hasResourceAcl(resourceInfo)) {
-    return unstable_getPublicResourceAccessModes(resourceInfo.acl.resourceAcl);
+    return unstable_getPublicResourceAccess(resourceInfo.acl.resourceAcl);
   }
   if (unstable_hasFallbackAcl(resourceInfo)) {
-    return unstable_getPublicDefaultAccessModes(resourceInfo.acl.fallbackAcl);
+    return unstable_getPublicDefaultAccess(resourceInfo.acl.fallbackAcl);
   }
   return null;
 }
@@ -66,16 +66,16 @@ export function unstable_getPublicAccessModes(
  *
  * Keep in mind that this function will not tell you:
  * - what access specific Agents have through other ACL rules, e.g. agent- or group-specific permissions.
- * - what access anyone has to child Resources, in case the associated Resource is a Container (see [[unstable_getDefaultResourceAccessModes]] for that).
+ * - what access anyone has to child Resources, in case the associated Resource is a Container (see [[unstable_getDefaultResourceAccess]] for that).
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
  * @param aclDataset The LitDataset that contains Access-Control List rules.
  * @returns Which Access Modes have been granted to everyone for the Resource the given ACL LitDataset is associated with.
  */
-export function unstable_getPublicResourceAccessModes(
+export function unstable_getPublicResourceAccess(
   aclDataset: unstable_AclDataset
-): unstable_AccessModes {
+): unstable_Access {
   const allRules = internal_getAclRules(aclDataset);
   const resourceRules = internal_getResourceAclRulesForResource(
     allRules,
@@ -85,7 +85,7 @@ export function unstable_getPublicResourceAccessModes(
     resourceRules,
     foaf.Agent
   );
-  const publicAccessModes = publicResourceRules.map(internal_getAccessModes);
+  const publicAccessModes = publicResourceRules.map(internal_getAccess);
   return internal_combineAccessModes(publicAccessModes);
 }
 
@@ -94,16 +94,16 @@ export function unstable_getPublicResourceAccessModes(
  *
  * Keep in mind that this function will not tell you:
  * - what access specific Agents have through other ACL rules, e.g. agent- or group-specific permissions.
- * - what access anyone has to the Container Resource itself (see [[unstable_getPublicResourceAccessModes]] for that).
+ * - what access anyone has to the Container Resource itself (see [[unstable_getPublicResourceAccess]] for that).
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
  * @param aclDataset The LitDataset that contains Access-Control List rules for a certain Container.
  * @returns Which Access Modes have been granted to everyone for the children of the Container associated with the given ACL LitDataset.
  */
-export function unstable_getPublicDefaultAccessModes(
+export function unstable_getPublicDefaultAccess(
   aclDataset: unstable_AclDataset
-): unstable_AccessModes {
+): unstable_Access {
   const allRules = internal_getAclRules(aclDataset);
   const resourceRules = internal_getDefaultAclRulesForResource(
     allRules,
@@ -113,7 +113,7 @@ export function unstable_getPublicDefaultAccessModes(
     resourceRules,
     foaf.Agent
   );
-  const publicAccessModes = publicResourceRules.map(internal_getAccessModes);
+  const publicAccessModes = publicResourceRules.map(internal_getAccess);
   return internal_combineAccessModes(publicAccessModes);
 }
 

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -32,18 +32,18 @@ import {
   unstable_fetchResourceInfoWithAcl,
   unstable_fetchLitDatasetWithAcl,
   unstable_hasResourceAcl,
-  unstable_getPublicAccessModes,
-  unstable_getAgentAccessModesOne,
+  unstable_getPublicAccess,
+  unstable_getAgentAccessOne,
   unstable_getFallbackAcl,
   unstable_getResourceAcl,
-  unstable_getAgentResourceAccessModesOne,
-  unstable_setAgentResourceAccessModes,
+  unstable_getAgentResourceAccessOne,
+  unstable_setAgentResourceAccess,
   unstable_saveAclFor,
   unstable_hasFallbackAcl,
   unstable_hasAccessibleAcl,
   unstable_createAclFromFallbackAcl,
-  unstable_getPublicDefaultAccessModes,
-  unstable_getPublicResourceAccessModes,
+  unstable_getPublicDefaultAccess,
+  unstable_getPublicResourceAccess,
 } from "./index";
 
 describe("End-to-end tests", () => {
@@ -113,14 +113,14 @@ describe("End-to-end tests", () => {
 
     expect(unstable_hasResourceAcl(datasetWithAcl)).toBe(true);
     expect(unstable_hasResourceAcl(datasetWithoutAcl)).toBe(false);
-    expect(unstable_getPublicAccessModes(datasetWithAcl)).toEqual({
+    expect(unstable_getPublicAccess(datasetWithAcl)).toEqual({
       read: true,
       append: true,
       write: true,
       control: true,
     });
     expect(
-      unstable_getAgentAccessModesOne(
+      unstable_getAgentAccessOne(
         datasetWithAcl,
         "https://vincentt.inrupt.net/profile/card#me"
       )
@@ -131,7 +131,7 @@ describe("End-to-end tests", () => {
       control: false,
     });
     expect(
-      unstable_getAgentAccessModesOne(
+      unstable_getAgentAccessOne(
         datasetWithoutAcl,
         "https://vincentt.inrupt.net/profile/card#me"
       )
@@ -150,14 +150,14 @@ describe("End-to-end tests", () => {
 
     if (unstable_hasResourceAcl(datasetWithAcl)) {
       const acl = unstable_getResourceAcl(datasetWithAcl);
-      const updatedAcl = unstable_setAgentResourceAccessModes(acl, fakeWebId, {
+      const updatedAcl = unstable_setAgentResourceAccess(acl, fakeWebId, {
         read: true,
         append: false,
         write: false,
         control: false,
       });
       const savedAcl = await unstable_saveAclFor(datasetWithAcl, updatedAcl);
-      const fakeWebIdAccess = unstable_getAgentResourceAccessModesOne(
+      const fakeWebIdAccess = unstable_getAgentResourceAccessOne(
         savedAcl,
         fakeWebId
       );
@@ -169,16 +169,12 @@ describe("End-to-end tests", () => {
       });
 
       // Cleanup
-      const cleanedAcl = unstable_setAgentResourceAccessModes(
-        savedAcl,
-        fakeWebId,
-        {
-          read: false,
-          append: false,
-          write: false,
-          control: false,
-        }
-      );
+      const cleanedAcl = unstable_setAgentResourceAccess(savedAcl, fakeWebId, {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      });
       await unstable_saveAclFor(datasetWithAcl, cleanedAcl);
     }
   });
@@ -194,8 +190,8 @@ describe("End-to-end tests", () => {
     ) {
       const newResourceAcl = unstable_createAclFromFallbackAcl(dataset);
       const existingFallbackAcl = unstable_getFallbackAcl(dataset);
-      expect(unstable_getPublicDefaultAccessModes(existingFallbackAcl)).toEqual(
-        unstable_getPublicResourceAccessModes(newResourceAcl)
+      expect(unstable_getPublicDefaultAccess(existingFallbackAcl)).toEqual(
+        unstable_getPublicResourceAccess(newResourceAcl)
       );
     }
   });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -97,17 +97,17 @@ import {
   unstable_hasResourceAcl,
   unstable_getResourceAcl,
   unstable_createAclFromFallbackAcl,
-  unstable_getAgentAccessModesOne,
-  unstable_getAgentAccessModesAll,
-  unstable_getAgentResourceAccessModesOne,
-  unstable_getAgentResourceAccessModesAll,
-  unstable_setAgentResourceAccessModes,
-  unstable_getAgentDefaultAccessModesOne,
-  unstable_getAgentDefaultAccessModesAll,
-  unstable_setAgentDefaultAccessModes,
-  unstable_getPublicAccessModes,
-  unstable_getPublicResourceAccessModes,
-  unstable_getPublicDefaultAccessModes,
+  unstable_getAgentAccessOne,
+  unstable_getAgentAccessAll,
+  unstable_getAgentResourceAccessOne,
+  unstable_getAgentResourceAccessAll,
+  unstable_setAgentResourceAccess,
+  unstable_getAgentDefaultAccessOne,
+  unstable_getAgentDefaultAccessAll,
+  unstable_setAgentDefaultAccess,
+  unstable_getPublicAccess,
+  unstable_getPublicResourceAccess,
+  unstable_getPublicDefaultAccess,
   unstable_hasAccessibleAcl,
   // Deprecated functions still exported for backwards compatibility:
   getStringUnlocalizedOne,
@@ -202,17 +202,17 @@ it("exports the public API from the entry file", () => {
   expect(unstable_hasResourceAcl).toBeDefined();
   expect(unstable_getResourceAcl).toBeDefined();
   expect(unstable_createAclFromFallbackAcl).toBeDefined();
-  expect(unstable_getAgentAccessModesOne).toBeDefined();
-  expect(unstable_getAgentAccessModesAll).toBeDefined();
-  expect(unstable_getAgentResourceAccessModesOne).toBeDefined();
-  expect(unstable_getAgentResourceAccessModesAll).toBeDefined();
-  expect(unstable_setAgentResourceAccessModes).toBeDefined();
-  expect(unstable_getAgentDefaultAccessModesOne).toBeDefined();
-  expect(unstable_getAgentDefaultAccessModesAll).toBeDefined();
-  expect(unstable_setAgentDefaultAccessModes).toBeDefined();
-  expect(unstable_getPublicAccessModes).toBeDefined();
-  expect(unstable_getPublicResourceAccessModes).toBeDefined();
-  expect(unstable_getPublicDefaultAccessModes).toBeDefined();
+  expect(unstable_getAgentAccessOne).toBeDefined();
+  expect(unstable_getAgentAccessAll).toBeDefined();
+  expect(unstable_getAgentResourceAccessOne).toBeDefined();
+  expect(unstable_getAgentResourceAccessAll).toBeDefined();
+  expect(unstable_setAgentResourceAccess).toBeDefined();
+  expect(unstable_getAgentDefaultAccessOne).toBeDefined();
+  expect(unstable_getAgentDefaultAccessAll).toBeDefined();
+  expect(unstable_setAgentDefaultAccess).toBeDefined();
+  expect(unstable_getPublicAccess).toBeDefined();
+  expect(unstable_getPublicResourceAccess).toBeDefined();
+  expect(unstable_getPublicDefaultAccess).toBeDefined();
   expect(unstable_hasAccessibleAcl).toBeDefined();
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,19 +138,19 @@ export {
 } from "./acl";
 export {
   unstable_AgentAccess,
-  unstable_getAgentAccessModesOne,
-  unstable_getAgentAccessModesAll,
-  unstable_getAgentResourceAccessModesOne,
-  unstable_getAgentResourceAccessModesAll,
-  unstable_setAgentResourceAccessModes,
-  unstable_getAgentDefaultAccessModesOne,
-  unstable_getAgentDefaultAccessModesAll,
-  unstable_setAgentDefaultAccessModes,
+  unstable_getAgentAccessOne,
+  unstable_getAgentAccessAll,
+  unstable_getAgentResourceAccessOne,
+  unstable_getAgentResourceAccessAll,
+  unstable_setAgentResourceAccess,
+  unstable_getAgentDefaultAccessOne,
+  unstable_getAgentDefaultAccessAll,
+  unstable_setAgentDefaultAccess,
 } from "./acl/agent";
 export {
-  unstable_getPublicAccessModes,
-  unstable_getPublicResourceAccessModes,
-  unstable_getPublicDefaultAccessModes,
+  unstable_getPublicAccess,
+  unstable_getPublicResourceAccess,
+  unstable_getPublicDefaultAccess,
 } from "./acl/agentClass";
 export {
   Url,
@@ -172,6 +172,6 @@ export {
   unstable_WithResourceAcl,
   unstable_AclDataset,
   unstable_AclRule,
-  unstable_AccessModes,
+  unstable_Access,
   unstable_UploadRequestInit,
 } from "./interfaces";

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -86,7 +86,7 @@ export type unstable_AclRule = Thing;
  *
  * Since that specification is not finalised yet, this interface is still experimental.
  */
-export type unstable_AccessModes =
+export type unstable_Access =
   // If someone has write permissions, they also have append permissions:
   | {
       read: boolean;
@@ -102,8 +102,8 @@ export type unstable_AccessModes =
     };
 
 type unstable_WacAllow = {
-  user: unstable_AccessModes;
-  public: unstable_AccessModes;
+  user: unstable_Access;
+  public: unstable_Access;
 };
 
 /**

--- a/src/litDataset.ts
+++ b/src/litDataset.ts
@@ -36,7 +36,7 @@ import {
   LocalNode,
   unstable_WithAcl,
   unstable_hasAccessibleAcl,
-  unstable_AccessModes,
+  unstable_Access,
   unstable_AclDataset,
   unstable_WithAccessibleAcl,
 } from "./interfaces";
@@ -512,7 +512,7 @@ function resolveLocalIrisInLitDataset<
 function parseWacAllowHeader(wacAllowHeader: string) {
   function parsePermissionStatement(
     permissionStatement: string
-  ): unstable_AccessModes {
+  ): unstable_Access {
     const permissions = permissionStatement.split(" ");
     const writePermission = permissions.includes("write");
     return writePermission

--- a/website/docs/tutorials/managing-access.md
+++ b/website/docs/tutorials/managing-access.md
@@ -54,19 +54,19 @@ and the ACL containing the associated access information.
 
 Given a [LitDataset](../glossary#litdataset) that has an ACL attached, you can check what access
 everyone has, regardless of whether they are authenticated or not. You can do so using
-[`unstable_getPublicAccessModes`](../api/modules/_acl_agentclass_#unstable_getpublicaccessmodes):
+[`unstable_getPublicAccess`](../api/modules/_acl_agentclass_#unstable_getpublicaccess):
 
 ```typescript
 import {
   unstable_fetchLitDatasetWithAcl,
-  unstable_getPublicAccessModes,
+  unstable_getPublicAccess,
 } from "@solid/lit-pod";
 
 const webId = "https://example.com/profile#webid";
 const litDatasetWithAcl = await unstable_fetchLitDatasetWithAcl(
   "https://example.com"
 );
-const publicAccess = unstable_getPublicAccessModes(litDatasetWithAcl);
+const publicAccess = unstable_getPublicAccess(litDatasetWithAcl);
 
 // => an object like
 //    { read: true, append: false, write: false, control: true }
@@ -79,19 +79,19 @@ Given a [LitDataset](../glossary#litdataset) that has an ACL attached, you can c
 specific agent has been granted, or get all agents for which access has been explicitly granted.
 
 To do the former, use
-[`unstable_getAgentAccessModesOne`](../api/modules/_acl_agent_#unstable_getagentaccessmodesone):
+[`unstable_getAgentAccessOne`](../api/modules/_acl_agent_#unstable_getagentaccessone):
 
 ```typescript
 import {
   unstable_fetchLitDatasetWithAcl,
-  unstable_getAgentAccessModesOne,
+  unstable_getAgentAccessOne,
 } from "@solid/lit-pod";
 
 const webId = "https://example.com/profile#webid";
 const litDatasetWithAcl = await unstable_fetchLitDatasetWithAcl(
   "https://example.com"
 );
-const agentAccess = unstable_getAgentAccessModesOne(litDatasetWithAcl, webId);
+const agentAccess = unstable_getAgentAccessOne(litDatasetWithAcl, webId);
 
 // => an object like
 //    { read: true, append: false, write: false, control: true }
@@ -99,18 +99,18 @@ const agentAccess = unstable_getAgentAccessModesOne(litDatasetWithAcl, webId);
 ```
 
 To get all agents to whom access was granted, use
-[`unstable_getAgentAccessModesAll`](../api/modules/_acl_agent_#unstable_getagentaccessmodesall):
+[`unstable_getAgentAccessAll`](../api/modules/_acl_agent_#unstable_getagentaccessall):
 
 ```typescript
 import {
   unstable_fetchLitDatasetWithAcl,
-  unstable_getAgentAccessModesAll,
+  unstable_getAgentAccessAll,
 } from "@solid/lit-pod";
 
 const litDatasetWithAcl = await unstable_fetchLitDatasetWithAcl(
   "https://example.com"
 );
-const accessByAgent = unstable_getAgentAccessModesAll(litDatasetWithAcl);
+const accessByAgent = unstable_getAgentAccessAll(litDatasetWithAcl);
 
 // => an object like
 //    {


### PR DESCRIPTION
Our function names were getting quite long, but the `-Modes` suffix
didn't actually add much information. While the codebase still
refers to each of Read, Append, Write and Control as Access Modes,
the object that lists each of those with a boolean value
representing whether they apply (effectively indicating what access
someone has) is now referred to as _Access_ rather than
_AccessModes_.

Also, since @pmcb55 is on a crusade against plurals, this also nicely sidesteps that issue ;)

@ajacksified This would be a breaking change. It should be easily applied with a search and replace (and I'm happy to submit a PR to do that), especially considering you're not yet doing much with ACLs, I think, but if this is too painful, let me know and I will make sure we keep aliases in place.

- [x] Relevant documentation, if any, has been written/updated.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
