### PR TITLE
Read Group permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,5 @@ First release! What's possible with this first release:
 - Store data back to Solid Pods.
 - Read data from datasets.
 - Manipulate data in datasets.
-- Inspect a user's and public permissions w.r.t. a given Resource. (Experimental.)
+- Inspect a user's, group's and public permissions w.r.t. a given Resource or child Resources of a Container. (Experimental.)
 - Retrieve, delete and/or write any file (including non-RDF) from/to a Pod. (Experimental.)

--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -43,6 +43,8 @@ import {
   unstable_getFallbackAcl,
   internal_accessModeIriStrings,
   internal_removeEmptyAclRules,
+  internal_getAclRulesForIri,
+  internal_getAccessByIri,
 } from "../acl";
 import { createThing, getThingAll, setThing } from "../thing";
 import { removeIri } from "../thing/remove";
@@ -310,20 +312,11 @@ export function unstable_setAgentDefaultAccess(
   return cleanedAcl;
 }
 
-/** @internal */
-export function getAclRulesForIri(
-  aclRules: unstable_AclRule[],
-  iri: IriString,
-  targetType: IriString
-): unstable_AclRule[] {
-  return aclRules.filter((rule) => getIriAll(rule, targetType).includes(iri));
-}
-
 function getAgentAclRulesForAgent(
   aclRules: unstable_AclRule[],
   agent: WebId
 ): unstable_AclRule[] {
-  return getAclRulesForIri(aclRules, agent, acl.agent);
+  return internal_getAclRulesForIri(aclRules, agent, acl.agent);
 }
 
 function getAgentAclRules(aclRules: unstable_AclRule[]): unstable_AclRule[] {
@@ -444,28 +437,5 @@ function intialiseAclRule(access: unstable_Access): unstable_AclRule {
 }
 
 function getAccessByAgent(aclRules: unstable_AclRule[]): unstable_AgentAccess {
-  return getAccessByIri(aclRules, acl.agent);
-}
-
-/** @internal */
-export function getAccessByIri(
-  aclRules: unstable_AclRule[],
-  targetType: IriString
-): unstable_AgentAccess {
-  const targetIriAccess: Record<IriString, unstable_Access> = {};
-
-  aclRules.forEach((rule) => {
-    const ruleTargetIri = getIriAll(rule, targetType);
-    const access = internal_getAccess(rule);
-
-    // A rule might apply to multiple agents. If multiple rules apply to the same agent, the Access
-    // Modes granted by those rules should be combined:
-    ruleTargetIri.forEach((targetIri) => {
-      targetIriAccess[targetIri] =
-        typeof targetIriAccess[targetIri] === "undefined"
-          ? access
-          : internal_combineAccessModes([targetIriAccess[targetIri], access]);
-    });
-  });
-  return targetIriAccess;
+  return internal_getAccessByIri(aclRules, acl.agent);
 }

--- a/src/acl/group.test.ts
+++ b/src/acl/group.test.ts
@@ -147,7 +147,7 @@ describe("getGroupAccessOne", () => {
     const litDataset = getMockDataset("https://some.pod/container/resource");
     const resourceAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/resource.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://some.pod/container/resource",
       { read: false, append: false, write: false, control: true },
       "resource"
@@ -160,7 +160,7 @@ describe("getGroupAccessOne", () => {
 
     const access = unstable_getGroupAccessOne(
       litDatasetWithAcl,
-      "https://some.pod/group#webId"
+      "https://some.pod/group#id"
     );
 
     expect(access).toEqual({
@@ -175,7 +175,7 @@ describe("getGroupAccessOne", () => {
     const litDataset = getMockDataset("https://some.pod/container/resource");
     const fallbackAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://some.pod/container/",
       { read: false, append: false, write: false, control: true },
       "default"
@@ -188,7 +188,7 @@ describe("getGroupAccessOne", () => {
 
     const access = unstable_getGroupAccessOne(
       litDatasetWithAcl,
-      "https://some.pod/group#webId"
+      "https://some.pod/group#id"
     );
 
     expect(access).toEqual({
@@ -221,14 +221,14 @@ describe("getGroupAccessOne", () => {
     const litDataset = getMockDataset("https://some.pod/container/resource");
     const resourceAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/resource.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://some.pod/container/resource",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
     const fallbackAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://some.pod/container/",
       { read: false, append: false, write: false, control: true },
       "default"
@@ -246,7 +246,7 @@ describe("getGroupAccessOne", () => {
 
     const access = unstable_getGroupAccessOne(
       litDatasetWithAcl,
-      "https://some.pod/group#webId"
+      "https://some.pod/group#id"
     );
 
     expect(access).toEqual({
@@ -261,14 +261,14 @@ describe("getGroupAccessOne", () => {
     const litDataset = getMockDataset("https://some.pod/container/");
     const resourceAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://some.pod/container/",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
     const resourceAclWithDefaultRules = addAclRuleQuads(
       resourceAcl,
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://some.pod/container/",
       { read: false, append: false, write: false, control: true },
       "default"
@@ -281,7 +281,7 @@ describe("getGroupAccessOne", () => {
 
     const access = unstable_getGroupAccessOne(
       litDatasetWithAcl,
-      "https://some.pod/group#webId"
+      "https://some.pod/group#id"
     );
 
     expect(access).toEqual({
@@ -296,14 +296,14 @@ describe("getGroupAccessOne", () => {
     const litDataset = getMockDataset("https://some.pod/container/resource");
     const fallbackAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://some.pod/container/",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
     const fallbackAclWithDefaultRules = addAclRuleQuads(
       fallbackAcl,
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://some.pod/container/",
       { read: false, append: false, write: false, control: true },
       "default"
@@ -316,7 +316,7 @@ describe("getGroupAccessOne", () => {
 
     const access = unstable_getGroupAccessOne(
       litDatasetWithAcl,
-      "https://some.pod/group#webId"
+      "https://some.pod/group#id"
     );
 
     expect(access).toEqual({
@@ -328,12 +328,12 @@ describe("getGroupAccessOne", () => {
   });
 });
 
-describe("getAgentAccessAll", () => {
-  it("returns the Resource's own applicable ACL rules, grouped by Group WebID", () => {
+describe("getGroupAccessAll", () => {
+  it("returns the Resource's own applicable ACL rules, grouped by Group URL", () => {
     const litDataset = getMockDataset("https://some.pod/container/resource");
     const resourceAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/resource.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://some.pod/container/resource",
       { read: false, append: false, write: false, control: true },
       "resource"
@@ -347,7 +347,7 @@ describe("getAgentAccessAll", () => {
     const access = unstable_getGroupAccessAll(litDatasetWithAcl);
 
     expect(access).toEqual({
-      "https://some.pod/group#webId": {
+      "https://some.pod/group#id": {
         read: false,
         append: false,
         write: false,
@@ -360,7 +360,7 @@ describe("getAgentAccessAll", () => {
     const litDataset = getMockDataset("https://some.pod/container/resource");
     const fallbackAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://some.pod/container/",
       { read: false, append: false, write: false, control: true },
       "default"
@@ -374,7 +374,7 @@ describe("getAgentAccessAll", () => {
     const access = unstable_getGroupAccessAll(litDatasetWithAcl);
 
     expect(access).toEqual({
-      "https://some.pod/group#webId": {
+      "https://some.pod/group#id": {
         read: false,
         append: false,
         write: false,
@@ -402,14 +402,14 @@ describe("getAgentAccessAll", () => {
     const litDataset = getMockDataset("https://some.pod/container/resource");
     const resourceAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/resource.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://some.pod/container/resource",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
     const fallbackAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://some.pod/container/",
       { read: false, append: false, write: false, control: true },
       "default"
@@ -428,7 +428,7 @@ describe("getAgentAccessAll", () => {
     const access = unstable_getGroupAccessAll(litDatasetWithAcl);
 
     expect(access).toEqual({
-      "https://some.pod/group#webId": {
+      "https://some.pod/group#id": {
         read: true,
         append: false,
         write: false,
@@ -441,7 +441,7 @@ describe("getAgentAccessAll", () => {
     const litDataset = getMockDataset("https://some.pod/container/resource");
     const resourceAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/resource.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://some.pod/container/resource",
       { read: true, append: false, write: false, control: false },
       "resource"
@@ -466,10 +466,10 @@ describe("getAgentAccessAll", () => {
 
     const access = unstable_getGroupAccessAll(litDatasetWithAcl);
 
-    // It only includes rules for agent "https://some.pod/group#webId",
+    // It only includes rules for agent "https://some.pod/group#id",
     // not for "https://some-other.pod/profileDoc#webId"
     expect(access).toEqual({
-      "https://some.pod/group#webId": {
+      "https://some.pod/group#id": {
         read: true,
         append: false,
         write: false,
@@ -482,14 +482,14 @@ describe("getAgentAccessAll", () => {
     const litDataset = getMockDataset("https://some.pod/container/");
     const resourceAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://some.pod/container/",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
     const resourceAclWithDefaultRules = addAclRuleQuads(
       resourceAcl,
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://some.pod/container/",
       { read: false, append: false, write: false, control: true },
       "default"
@@ -503,7 +503,7 @@ describe("getAgentAccessAll", () => {
     const access = unstable_getGroupAccessAll(litDatasetWithAcl);
 
     expect(access).toEqual({
-      "https://some.pod/group#webId": {
+      "https://some.pod/group#id": {
         read: true,
         append: false,
         write: false,
@@ -516,14 +516,14 @@ describe("getAgentAccessAll", () => {
     const litDataset = getMockDataset("https://some.pod/container/resource");
     const fallbackAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://some.pod/container/",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
     const fallbackAclWithDefaultRules = addAclRuleQuads(
       fallbackAcl,
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://some.pod/container/",
       { read: false, append: false, write: false, control: true },
       "default"
@@ -537,7 +537,7 @@ describe("getAgentAccessAll", () => {
     const access = unstable_getGroupAccessAll(litDatasetWithAcl);
 
     expect(access).toEqual({
-      "https://some.pod/group#webId": {
+      "https://some.pod/group#id": {
         read: false,
         append: false,
         write: false,
@@ -551,7 +551,7 @@ describe("getGroupResourceAccessOne", () => {
   it("returns the applicable Access Modes for a single Group", () => {
     const resourceAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://arbitrary.pod/resource",
       { read: true, append: false, write: false, control: true },
       "resource"
@@ -559,7 +559,7 @@ describe("getGroupResourceAccessOne", () => {
 
     const groupAccess = unstable_getGroupResourceAccessOne(
       resourceAcl,
-      "https://some.pod/group#webId"
+      "https://some.pod/group#id"
     );
 
     expect(groupAccess).toEqual({
@@ -573,14 +573,14 @@ describe("getGroupResourceAccessOne", () => {
   it("combines Access Modes defined for a given Group in separate rules", () => {
     let resourceAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://arbitrary.pod/resource",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
     resourceAcl = addAclRuleQuads(
       resourceAcl,
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://arbitrary.pod/resource",
       { read: false, append: true, write: false, control: false },
       "resource"
@@ -588,7 +588,7 @@ describe("getGroupResourceAccessOne", () => {
 
     const groupAccess = unstable_getGroupResourceAccessOne(
       resourceAcl,
-      "https://some.pod/group#webId"
+      "https://some.pod/group#id"
     );
 
     expect(groupAccess).toEqual({
@@ -602,7 +602,7 @@ describe("getGroupResourceAccessOne", () => {
   it("returns false for all Access Modes if there are no ACL rules for the given Group", () => {
     const resourceAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://arbitrary.pod/resource",
       { read: true, append: false, write: false, control: false },
       "resource"
@@ -610,7 +610,7 @@ describe("getGroupResourceAccessOne", () => {
 
     const groupAccess = unstable_getGroupResourceAccessOne(
       resourceAcl,
-      "https://some-other.pod/group#webId"
+      "https://some-other.pod/group#id"
     );
 
     expect(groupAccess).toEqual({
@@ -624,14 +624,14 @@ describe("getGroupResourceAccessOne", () => {
   it("ignores ACL rules that apply to a different Group", () => {
     let resourceAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
-      "https://some-other.pod/group#webId",
+      "https://some-other.pod/group#id",
       "https://arbitrary.pod/resource",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
     resourceAcl = addAclRuleQuads(
       resourceAcl,
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://arbitrary.pod/resource",
       { read: false, append: true, write: false, control: false },
       "resource"
@@ -639,7 +639,7 @@ describe("getGroupResourceAccessOne", () => {
 
     const groupAccess = unstable_getGroupResourceAccessOne(
       resourceAcl,
-      "https://some.pod/group#webId"
+      "https://some.pod/group#id"
     );
 
     expect(groupAccess).toEqual({
@@ -653,14 +653,14 @@ describe("getGroupResourceAccessOne", () => {
   it("ignores ACL rules that apply to a different Resource", () => {
     let resourceAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/resource.acl"),
-      "https://arbitrary.pod/group#webId",
+      "https://arbitrary.pod/group#id",
       "https://some-other.pod/resource",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
     resourceAcl = addAclRuleQuads(
       resourceAcl,
-      "https://arbitrary.pod/group#webId",
+      "https://arbitrary.pod/group#id",
       "https://some.pod/resource",
       { read: false, append: true, write: false, control: false },
       "resource"
@@ -668,7 +668,7 @@ describe("getGroupResourceAccessOne", () => {
 
     const groupAccess = unstable_getGroupResourceAccessOne(
       resourceAcl,
-      "https://arbitrary.pod/group#webId"
+      "https://arbitrary.pod/group#id"
     );
 
     expect(groupAccess).toEqual({
@@ -684,14 +684,14 @@ describe("getGroupResourceAccessAll", () => {
   it("returns the applicable Access Modes for all Groups for whom Access Modes have been defined", () => {
     let resourceAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
-      "https://some-other.pod/group#webId",
+      "https://some-other.pod/group#id",
       "https://arbitrary.pod/resource",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
     resourceAcl = addAclRuleQuads(
       resourceAcl,
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://arbitrary.pod/resource",
       { read: false, append: true, write: false, control: false },
       "resource"
@@ -700,13 +700,13 @@ describe("getGroupResourceAccessAll", () => {
     const groupAccess = unstable_getGroupResourceAccessAll(resourceAcl);
 
     expect(groupAccess).toEqual({
-      "https://some.pod/group#webId": {
+      "https://some.pod/group#id": {
         read: false,
         append: true,
         write: false,
         control: false,
       },
-      "https://some-other.pod/group#webId": {
+      "https://some-other.pod/group#id": {
         read: true,
         append: false,
         write: false,
@@ -718,14 +718,14 @@ describe("getGroupResourceAccessAll", () => {
   it("combines Access Modes defined for the same Groups in different Rules", () => {
     let resourceAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://arbitrary.pod/resource",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
     resourceAcl = addAclRuleQuads(
       resourceAcl,
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://arbitrary.pod/resource",
       { read: false, append: true, write: false, control: false },
       "resource"
@@ -734,7 +734,7 @@ describe("getGroupResourceAccessAll", () => {
     const groupAccess = unstable_getGroupResourceAccessAll(resourceAcl);
 
     expect(groupAccess).toEqual({
-      "https://some.pod/group#webId": {
+      "https://some.pod/group#id": {
         read: true,
         append: true,
         write: false,
@@ -746,7 +746,7 @@ describe("getGroupResourceAccessAll", () => {
   it("returns Access Modes for all Groups even if they are assigned in the same Rule", () => {
     let resourceAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://arbitrary.pod/resource",
       { read: true, append: false, write: false, control: false },
       "resource"
@@ -756,20 +756,20 @@ describe("getGroupResourceAccessAll", () => {
       DataFactory.quad(
         oneQuad.subject,
         DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agentGroup"),
-        DataFactory.namedNode("https://some-other.pod/group#webId")
+        DataFactory.namedNode("https://some-other.pod/group#id")
       )
     );
 
     const agentAccess = unstable_getGroupResourceAccessAll(resourceAcl);
 
     expect(agentAccess).toEqual({
-      "https://some.pod/group#webId": {
+      "https://some.pod/group#id": {
         read: true,
         append: false,
         write: false,
         control: false,
       },
-      "https://some-other.pod/group#webId": {
+      "https://some-other.pod/group#id": {
         read: true,
         append: false,
         write: false,
@@ -781,7 +781,7 @@ describe("getGroupResourceAccessAll", () => {
   it("ignores ACL rules that do not apply to a Group", () => {
     let resourceAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://arbitrary.pod/resource",
       { read: true, append: false, write: false, control: false },
       "resource"
@@ -814,7 +814,7 @@ describe("getGroupResourceAccessAll", () => {
     const groupAccess = unstable_getGroupResourceAccessAll(resourceAcl);
 
     expect(groupAccess).toEqual({
-      "https://some.pod/group#webId": {
+      "https://some.pod/group#id": {
         read: true,
         append: false,
         write: false,
@@ -826,14 +826,14 @@ describe("getGroupResourceAccessAll", () => {
   it("ignores ACL rules that apply to a different Resource", () => {
     let resourceAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/resource.acl"),
-      "https://arbitrary.pod/group#webId",
+      "https://arbitrary.pod/group#id",
       "https://some-other.pod/resource",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
     resourceAcl = addAclRuleQuads(
       resourceAcl,
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://some.pod/resource",
       { read: false, append: true, write: false, control: false },
       "resource"
@@ -842,7 +842,7 @@ describe("getGroupResourceAccessAll", () => {
     const groupAccess = unstable_getGroupResourceAccessAll(resourceAcl);
 
     expect(groupAccess).toEqual({
-      "https://some.pod/group#webId": {
+      "https://some.pod/group#id": {
         read: false,
         append: true,
         write: false,
@@ -856,7 +856,7 @@ describe("getGroupDefaultAccessOne", () => {
   it("returns the applicable Access Modes for a single Group", () => {
     const containerAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://arbitrary.pod/container/",
       { read: true, append: false, write: false, control: true },
       "default"
@@ -864,7 +864,7 @@ describe("getGroupDefaultAccessOne", () => {
 
     const groupAccess = unstable_getGroupDefaultAccessOne(
       containerAcl,
-      "https://some.pod/group#webId"
+      "https://some.pod/group#id"
     );
 
     expect(groupAccess).toEqual({
@@ -878,14 +878,14 @@ describe("getGroupDefaultAccessOne", () => {
   it("combines Access Modes defined for a given Group in separate rules", () => {
     let containerAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://arbitrary.pod/container/",
       { read: true, append: false, write: false, control: false },
       "default"
     );
     containerAcl = addAclRuleQuads(
       containerAcl,
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://arbitrary.pod/container/",
       { read: false, append: true, write: false, control: false },
       "default"
@@ -893,7 +893,7 @@ describe("getGroupDefaultAccessOne", () => {
 
     const groupAccess = unstable_getGroupDefaultAccessOne(
       containerAcl,
-      "https://some.pod/group#webId"
+      "https://some.pod/group#id"
     );
 
     expect(groupAccess).toEqual({
@@ -907,7 +907,7 @@ describe("getGroupDefaultAccessOne", () => {
   it("returns false for all Access Modes if there are no ACL rules for the given Group", () => {
     const containerAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://arbitrary.pod/container/",
       { read: true, append: false, write: false, control: false },
       "default"
@@ -915,7 +915,7 @@ describe("getGroupDefaultAccessOne", () => {
 
     const groupAccess = unstable_getGroupDefaultAccessOne(
       containerAcl,
-      "https://some-other.pod/group#webId"
+      "https://some-other.pod/group#id"
     );
 
     expect(groupAccess).toEqual({
@@ -929,14 +929,14 @@ describe("getGroupDefaultAccessOne", () => {
   it("ignores ACL rules that apply to a different Group", () => {
     let containerAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
-      "https://some-other.pod/group#webId",
+      "https://some-other.pod/group#id",
       "https://arbitrary.pod/container/",
       { read: true, append: false, write: false, control: false },
       "default"
     );
     containerAcl = addAclRuleQuads(
       containerAcl,
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://arbitrary.pod/container/",
       { read: false, append: true, write: false, control: false },
       "default"
@@ -944,7 +944,7 @@ describe("getGroupDefaultAccessOne", () => {
 
     const groupAccess = unstable_getGroupDefaultAccessOne(
       containerAcl,
-      "https://some.pod/group#webId"
+      "https://some.pod/group#id"
     );
 
     expect(groupAccess).toEqual({
@@ -958,14 +958,14 @@ describe("getGroupDefaultAccessOne", () => {
   it("ignores ACL rules that apply to a different Resource", () => {
     let containerAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
-      "https://arbitrary.pod/group#webId",
+      "https://arbitrary.pod/group#id",
       "https://some-other.pod/container/",
       { read: true, append: false, write: false, control: false },
       "default"
     );
     containerAcl = addAclRuleQuads(
       containerAcl,
-      "https://arbitrary.pod/group#webId",
+      "https://arbitrary.pod/group#id",
       "https://some.pod/container/",
       { read: false, append: true, write: false, control: false },
       "default"
@@ -973,7 +973,7 @@ describe("getGroupDefaultAccessOne", () => {
 
     const groupAccess = unstable_getGroupDefaultAccessOne(
       containerAcl,
-      "https://arbitrary.pod/group#webId"
+      "https://arbitrary.pod/group#id"
     );
 
     expect(groupAccess).toEqual({
@@ -989,14 +989,14 @@ describe("getGroupDefaultAccessAll", () => {
   it("returns the applicable Access Modes for all Groups for whom Access Modes have been defined", () => {
     let containerAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
-      "https://some-other.pod/group#webId",
+      "https://some-other.pod/group#id",
       "https://arbitrary.pod/container/",
       { read: true, append: false, write: false, control: false },
       "default"
     );
     containerAcl = addAclRuleQuads(
       containerAcl,
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://arbitrary.pod/container/",
       { read: false, append: true, write: false, control: false },
       "default"
@@ -1005,13 +1005,13 @@ describe("getGroupDefaultAccessAll", () => {
     const groupAccess = unstable_getGroupDefaultAccessAll(containerAcl);
 
     expect(groupAccess).toEqual({
-      "https://some.pod/group#webId": {
+      "https://some.pod/group#id": {
         read: false,
         append: true,
         write: false,
         control: false,
       },
-      "https://some-other.pod/group#webId": {
+      "https://some-other.pod/group#id": {
         read: true,
         append: false,
         write: false,
@@ -1023,14 +1023,14 @@ describe("getGroupDefaultAccessAll", () => {
   it("combines Access Modes defined for the same Group in different Rules", () => {
     let containerAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://arbitrary.pod/container/",
       { read: true, append: false, write: false, control: false },
       "default"
     );
     containerAcl = addAclRuleQuads(
       containerAcl,
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://arbitrary.pod/container/",
       { read: false, append: true, write: false, control: false },
       "default"
@@ -1039,7 +1039,7 @@ describe("getGroupDefaultAccessAll", () => {
     const groupAccess = unstable_getGroupDefaultAccessAll(containerAcl);
 
     expect(groupAccess).toEqual({
-      "https://some.pod/group#webId": {
+      "https://some.pod/group#id": {
         read: true,
         append: true,
         write: false,
@@ -1051,7 +1051,7 @@ describe("getGroupDefaultAccessAll", () => {
   it("returns Access Modes for all Groups even if they are assigned in the same Rule", () => {
     let containerAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acln"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://arbitrary.pod/container/",
       { read: true, append: false, write: false, control: false },
       "default"
@@ -1061,20 +1061,20 @@ describe("getGroupDefaultAccessAll", () => {
       DataFactory.quad(
         oneQuad.subject,
         DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agentGroup"),
-        DataFactory.namedNode("https://some-other.pod/group#webId")
+        DataFactory.namedNode("https://some-other.pod/group#id")
       )
     );
 
     const groupAccess = unstable_getGroupDefaultAccessAll(containerAcl);
 
     expect(groupAccess).toEqual({
-      "https://some.pod/group#webId": {
+      "https://some.pod/group#id": {
         read: true,
         append: false,
         write: false,
         control: false,
       },
-      "https://some-other.pod/group#webId": {
+      "https://some-other.pod/group#id": {
         read: true,
         append: false,
         write: false,
@@ -1086,7 +1086,7 @@ describe("getGroupDefaultAccessAll", () => {
   it("ignores ACL rules that do not apply to a Group", () => {
     let containerAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://arbitrary.pod/container/",
       { read: true, append: false, write: false, control: false },
       "default"
@@ -1119,7 +1119,7 @@ describe("getGroupDefaultAccessAll", () => {
     const groupAccess = unstable_getGroupDefaultAccessAll(containerAcl);
 
     expect(groupAccess).toEqual({
-      "https://some.pod/group#webId": {
+      "https://some.pod/group#id": {
         read: true,
         append: false,
         write: false,
@@ -1131,14 +1131,14 @@ describe("getGroupDefaultAccessAll", () => {
   it("ignores ACL rules that apply to a different Resource", () => {
     let containerAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
-      "https://arbitrary.pod/group#webId",
+      "https://arbitrary.pod/group#id",
       "https://some-other.pod/container/",
       { read: true, append: false, write: false, control: false },
       "default"
     );
     containerAcl = addAclRuleQuads(
       containerAcl,
-      "https://some.pod/group#webId",
+      "https://some.pod/group#id",
       "https://some.pod/container/",
       { read: false, append: true, write: false, control: false },
       "default"
@@ -1147,7 +1147,7 @@ describe("getGroupDefaultAccessAll", () => {
     const groupAccess = unstable_getGroupDefaultAccessAll(containerAcl);
 
     expect(groupAccess).toEqual({
-      "https://some.pod/group#webId": {
+      "https://some.pod/group#id": {
         read: false,
         append: true,
         write: false,

--- a/src/acl/group.test.ts
+++ b/src/acl/group.test.ts
@@ -1,0 +1,1158 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { dataset } from "@rdfjs/dataset";
+import {
+  LitDataset,
+  WithResourceInfo,
+  IriString,
+  unstable_Access,
+  unstable_AclDataset,
+  unstable_WithAcl,
+  WebId,
+} from "../interfaces";
+import { DataFactory } from "../rdfjs";
+import {
+  unstable_getGroupDefaultAccessOne,
+  unstable_getGroupResourceAccessOne,
+  unstable_getGroupResourceAccessAll,
+  unstable_getGroupDefaultAccessAll,
+  unstable_getGroupAccessOne,
+  unstable_getGroupAccessAll,
+} from "./group";
+
+function addAclRuleQuads(
+  aclDataset: LitDataset & WithResourceInfo,
+  group: WebId,
+  resource: IriString,
+  access: unstable_Access,
+  type: "resource" | "default"
+): unstable_AclDataset {
+  const subjectIri = resource + "#" + encodeURIComponent(group) + Math.random();
+  aclDataset.add(
+    DataFactory.quad(
+      DataFactory.namedNode(subjectIri),
+      DataFactory.namedNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+      DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Authorization")
+    )
+  );
+  aclDataset.add(
+    DataFactory.quad(
+      DataFactory.namedNode(subjectIri),
+      DataFactory.namedNode(
+        type === "resource"
+          ? "http://www.w3.org/ns/auth/acl#accessTo"
+          : "http://www.w3.org/ns/auth/acl#default"
+      ),
+      DataFactory.namedNode(resource)
+    )
+  );
+  aclDataset.add(
+    DataFactory.quad(
+      DataFactory.namedNode(subjectIri),
+      DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agentGroup"),
+      DataFactory.namedNode(group)
+    )
+  );
+  if (access.read) {
+    aclDataset.add(
+      DataFactory.quad(
+        DataFactory.namedNode(subjectIri),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#mode"),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Read")
+      )
+    );
+  }
+  if (access.append) {
+    aclDataset.add(
+      DataFactory.quad(
+        DataFactory.namedNode(subjectIri),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#mode"),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Append")
+      )
+    );
+  }
+  if (access.write) {
+    aclDataset.add(
+      DataFactory.quad(
+        DataFactory.namedNode(subjectIri),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#mode"),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Write")
+      )
+    );
+  }
+  if (access.control) {
+    aclDataset.add(
+      DataFactory.quad(
+        DataFactory.namedNode(subjectIri),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#mode"),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Control")
+      )
+    );
+  }
+
+  return Object.assign(aclDataset, { accessTo: resource });
+}
+
+function addAclDatasetToLitDataset(
+  litDataset: LitDataset & WithResourceInfo,
+  aclDataset: unstable_AclDataset,
+  type: "resource" | "fallback"
+): LitDataset & WithResourceInfo & unstable_WithAcl {
+  const acl: unstable_WithAcl["acl"] = {
+    fallbackAcl: null,
+    resourceAcl: null,
+    ...(((litDataset as any) as unstable_WithAcl).acl ?? {}),
+  };
+  if (type === "resource") {
+    litDataset.resourceInfo.unstable_aclUrl =
+      aclDataset.resourceInfo.fetchedFrom;
+    aclDataset.accessTo = litDataset.resourceInfo.fetchedFrom;
+    acl.resourceAcl = aclDataset;
+  } else if (type === "fallback") {
+    acl.fallbackAcl = aclDataset;
+  }
+  return Object.assign(litDataset, { acl: acl });
+}
+
+function getMockDataset(fetchedFrom: IriString): LitDataset & WithResourceInfo {
+  return Object.assign(dataset(), {
+    resourceInfo: {
+      fetchedFrom: fetchedFrom,
+      isLitDataset: true,
+    },
+  });
+}
+
+describe("getGroupAccessOne", () => {
+  it("returns the Resource's own applicable ACL rules", () => {
+    const litDataset = getMockDataset("https://some.pod/container/resource");
+    const resourceAcl = addAclRuleQuads(
+      getMockDataset("https://some.pod/container/resource.acl"),
+      "https://some.pod/group#webId",
+      "https://some.pod/container/resource",
+      { read: false, append: false, write: false, control: true },
+      "resource"
+    );
+    const litDatasetWithAcl = addAclDatasetToLitDataset(
+      litDataset,
+      resourceAcl,
+      "resource"
+    );
+
+    const access = unstable_getGroupAccessOne(
+      litDatasetWithAcl,
+      "https://some.pod/group#webId"
+    );
+
+    expect(access).toEqual({
+      read: false,
+      append: false,
+      write: false,
+      control: true,
+    });
+  });
+
+  it("returns the fallback ACL rules if no Resource ACL LitDataset is available", () => {
+    const litDataset = getMockDataset("https://some.pod/container/resource");
+    const fallbackAcl = addAclRuleQuads(
+      getMockDataset("https://some.pod/container/.acl"),
+      "https://some.pod/group#webId",
+      "https://some.pod/container/",
+      { read: false, append: false, write: false, control: true },
+      "default"
+    );
+    const litDatasetWithAcl = addAclDatasetToLitDataset(
+      litDataset,
+      fallbackAcl,
+      "fallback"
+    );
+
+    const access = unstable_getGroupAccessOne(
+      litDatasetWithAcl,
+      "https://some.pod/group#webId"
+    );
+
+    expect(access).toEqual({
+      read: false,
+      append: false,
+      write: false,
+      control: true,
+    });
+  });
+
+  it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
+    const litDataset = getMockDataset("https://some.pod/container/resource");
+    const inaccessibleAcl: unstable_WithAcl = {
+      acl: { fallbackAcl: null, resourceAcl: null },
+    };
+    const litDatasetWithInaccessibleAcl = Object.assign(
+      litDataset,
+      inaccessibleAcl
+    );
+
+    expect(
+      unstable_getGroupAccessOne(
+        litDatasetWithInaccessibleAcl,
+        "https://arbitrary.pod/profileDoc#webId"
+      )
+    ).toBeNull();
+  });
+
+  it("ignores the fallback ACL rules if a Resource ACL LitDataset is available", () => {
+    const litDataset = getMockDataset("https://some.pod/container/resource");
+    const resourceAcl = addAclRuleQuads(
+      getMockDataset("https://some.pod/container/resource.acl"),
+      "https://some.pod/group#webId",
+      "https://some.pod/container/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+    const fallbackAcl = addAclRuleQuads(
+      getMockDataset("https://some.pod/container/.acl"),
+      "https://some.pod/group#webId",
+      "https://some.pod/container/",
+      { read: false, append: false, write: false, control: true },
+      "default"
+    );
+    const litDatasetWithJustResourceAcl = addAclDatasetToLitDataset(
+      litDataset,
+      resourceAcl,
+      "resource"
+    );
+    const litDatasetWithAcl = addAclDatasetToLitDataset(
+      litDatasetWithJustResourceAcl,
+      fallbackAcl,
+      "fallback"
+    );
+
+    const access = unstable_getGroupAccessOne(
+      litDatasetWithAcl,
+      "https://some.pod/group#webId"
+    );
+
+    expect(access).toEqual({
+      read: true,
+      append: false,
+      write: false,
+      control: false,
+    });
+  });
+
+  it("ignores default ACL rules from the Resource's own ACL LitDataset", () => {
+    const litDataset = getMockDataset("https://some.pod/container/");
+    const resourceAcl = addAclRuleQuads(
+      getMockDataset("https://some.pod/container/.acl"),
+      "https://some.pod/group#webId",
+      "https://some.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+    const resourceAclWithDefaultRules = addAclRuleQuads(
+      resourceAcl,
+      "https://some.pod/group#webId",
+      "https://some.pod/container/",
+      { read: false, append: false, write: false, control: true },
+      "default"
+    );
+    const litDatasetWithAcl = addAclDatasetToLitDataset(
+      litDataset,
+      resourceAclWithDefaultRules,
+      "resource"
+    );
+
+    const access = unstable_getGroupAccessOne(
+      litDatasetWithAcl,
+      "https://some.pod/group#webId"
+    );
+
+    expect(access).toEqual({
+      read: true,
+      append: false,
+      write: false,
+      control: false,
+    });
+  });
+
+  it("ignores Resource ACL rules from the fallback ACL LitDataset", () => {
+    const litDataset = getMockDataset("https://some.pod/container/resource");
+    const fallbackAcl = addAclRuleQuads(
+      getMockDataset("https://some.pod/container/.acl"),
+      "https://some.pod/group#webId",
+      "https://some.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+    const fallbackAclWithDefaultRules = addAclRuleQuads(
+      fallbackAcl,
+      "https://some.pod/group#webId",
+      "https://some.pod/container/",
+      { read: false, append: false, write: false, control: true },
+      "default"
+    );
+    const litDatasetWithAcl = addAclDatasetToLitDataset(
+      litDataset,
+      fallbackAclWithDefaultRules,
+      "fallback"
+    );
+
+    const access = unstable_getGroupAccessOne(
+      litDatasetWithAcl,
+      "https://some.pod/group#webId"
+    );
+
+    expect(access).toEqual({
+      read: false,
+      append: false,
+      write: false,
+      control: true,
+    });
+  });
+});
+
+describe("getAgentAccessAll", () => {
+  it("returns the Resource's own applicable ACL rules, grouped by Group WebID", () => {
+    const litDataset = getMockDataset("https://some.pod/container/resource");
+    const resourceAcl = addAclRuleQuads(
+      getMockDataset("https://some.pod/container/resource.acl"),
+      "https://some.pod/group#webId",
+      "https://some.pod/container/resource",
+      { read: false, append: false, write: false, control: true },
+      "resource"
+    );
+    const litDatasetWithAcl = addAclDatasetToLitDataset(
+      litDataset,
+      resourceAcl,
+      "resource"
+    );
+
+    const access = unstable_getGroupAccessAll(litDatasetWithAcl);
+
+    expect(access).toEqual({
+      "https://some.pod/group#webId": {
+        read: false,
+        append: false,
+        write: false,
+        control: true,
+      },
+    });
+  });
+
+  it("returns the fallback ACL rules if no Resource ACL LitDataset is available", () => {
+    const litDataset = getMockDataset("https://some.pod/container/resource");
+    const fallbackAcl = addAclRuleQuads(
+      getMockDataset("https://some.pod/container/.acl"),
+      "https://some.pod/group#webId",
+      "https://some.pod/container/",
+      { read: false, append: false, write: false, control: true },
+      "default"
+    );
+    const litDatasetWithAcl = addAclDatasetToLitDataset(
+      litDataset,
+      fallbackAcl,
+      "fallback"
+    );
+
+    const access = unstable_getGroupAccessAll(litDatasetWithAcl);
+
+    expect(access).toEqual({
+      "https://some.pod/group#webId": {
+        read: false,
+        append: false,
+        write: false,
+        control: true,
+      },
+    });
+  });
+
+  it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
+    const litDataset = getMockDataset("https://some.pod/container/resource");
+    const inaccessibleAcl: unstable_WithAcl = {
+      acl: { fallbackAcl: null, resourceAcl: null },
+    };
+    const litDatasetWithInaccessibleAcl = Object.assign(
+      litDataset,
+      inaccessibleAcl
+    );
+
+    expect(
+      unstable_getGroupAccessAll(litDatasetWithInaccessibleAcl)
+    ).toBeNull();
+  });
+
+  it("ignores the fallback ACL rules if a Resource ACL LitDataset is available", () => {
+    const litDataset = getMockDataset("https://some.pod/container/resource");
+    const resourceAcl = addAclRuleQuads(
+      getMockDataset("https://some.pod/container/resource.acl"),
+      "https://some.pod/group#webId",
+      "https://some.pod/container/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+    const fallbackAcl = addAclRuleQuads(
+      getMockDataset("https://some.pod/container/.acl"),
+      "https://some.pod/group#webId",
+      "https://some.pod/container/",
+      { read: false, append: false, write: false, control: true },
+      "default"
+    );
+    const litDatasetWithJustResourceAcl = addAclDatasetToLitDataset(
+      litDataset,
+      resourceAcl,
+      "resource"
+    );
+    const litDatasetWithAcl = addAclDatasetToLitDataset(
+      litDatasetWithJustResourceAcl,
+      fallbackAcl,
+      "fallback"
+    );
+
+    const access = unstable_getGroupAccessAll(litDatasetWithAcl);
+
+    expect(access).toEqual({
+      "https://some.pod/group#webId": {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      },
+    });
+  });
+
+  it("does not merge fallback ACL rules with a Resource's own ACL rules, if available", () => {
+    const litDataset = getMockDataset("https://some.pod/container/resource");
+    const resourceAcl = addAclRuleQuads(
+      getMockDataset("https://some.pod/container/resource.acl"),
+      "https://some.pod/group#webId",
+      "https://some.pod/container/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+    const fallbackAcl = addAclRuleQuads(
+      getMockDataset("https://some.pod/container/.acl"),
+      "https://some-other.pod/profileDoc#webId",
+      "https://some.pod/container/",
+      { read: false, append: false, write: false, control: true },
+      "default"
+    );
+    const litDatasetWithJustResourceAcl = addAclDatasetToLitDataset(
+      litDataset,
+      resourceAcl,
+      "resource"
+    );
+    const litDatasetWithAcl = addAclDatasetToLitDataset(
+      litDatasetWithJustResourceAcl,
+      fallbackAcl,
+      "fallback"
+    );
+
+    const access = unstable_getGroupAccessAll(litDatasetWithAcl);
+
+    // It only includes rules for agent "https://some.pod/group#webId",
+    // not for "https://some-other.pod/profileDoc#webId"
+    expect(access).toEqual({
+      "https://some.pod/group#webId": {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      },
+    });
+  });
+
+  it("ignores default ACL rules from the Resource's own ACL LitDataset", () => {
+    const litDataset = getMockDataset("https://some.pod/container/");
+    const resourceAcl = addAclRuleQuads(
+      getMockDataset("https://some.pod/container/.acl"),
+      "https://some.pod/group#webId",
+      "https://some.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+    const resourceAclWithDefaultRules = addAclRuleQuads(
+      resourceAcl,
+      "https://some.pod/group#webId",
+      "https://some.pod/container/",
+      { read: false, append: false, write: false, control: true },
+      "default"
+    );
+    const litDatasetWithAcl = addAclDatasetToLitDataset(
+      litDataset,
+      resourceAclWithDefaultRules,
+      "resource"
+    );
+
+    const access = unstable_getGroupAccessAll(litDatasetWithAcl);
+
+    expect(access).toEqual({
+      "https://some.pod/group#webId": {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      },
+    });
+  });
+
+  it("ignores Resource ACL rules from the fallback ACL LitDataset", () => {
+    const litDataset = getMockDataset("https://some.pod/container/resource");
+    const fallbackAcl = addAclRuleQuads(
+      getMockDataset("https://some.pod/container/.acl"),
+      "https://some.pod/group#webId",
+      "https://some.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+    const fallbackAclWithDefaultRules = addAclRuleQuads(
+      fallbackAcl,
+      "https://some.pod/group#webId",
+      "https://some.pod/container/",
+      { read: false, append: false, write: false, control: true },
+      "default"
+    );
+    const litDatasetWithAcl = addAclDatasetToLitDataset(
+      litDataset,
+      fallbackAclWithDefaultRules,
+      "fallback"
+    );
+
+    const access = unstable_getGroupAccessAll(litDatasetWithAcl);
+
+    expect(access).toEqual({
+      "https://some.pod/group#webId": {
+        read: false,
+        append: false,
+        write: false,
+        control: true,
+      },
+    });
+  });
+});
+
+describe("getGroupResourceAccessOne", () => {
+  it("returns the applicable Access Modes for a single Group", () => {
+    const resourceAcl = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://some.pod/group#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: true },
+      "resource"
+    );
+
+    const groupAccess = unstable_getGroupResourceAccessOne(
+      resourceAcl,
+      "https://some.pod/group#webId"
+    );
+
+    expect(groupAccess).toEqual({
+      read: true,
+      append: false,
+      write: false,
+      control: true,
+    });
+  });
+
+  it("combines Access Modes defined for a given Group in separate rules", () => {
+    let resourceAcl = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://some.pod/group#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+    resourceAcl = addAclRuleQuads(
+      resourceAcl,
+      "https://some.pod/group#webId",
+      "https://arbitrary.pod/resource",
+      { read: false, append: true, write: false, control: false },
+      "resource"
+    );
+
+    const groupAccess = unstable_getGroupResourceAccessOne(
+      resourceAcl,
+      "https://some.pod/group#webId"
+    );
+
+    expect(groupAccess).toEqual({
+      read: true,
+      append: true,
+      write: false,
+      control: false,
+    });
+  });
+
+  it("returns false for all Access Modes if there are no ACL rules for the given Group", () => {
+    const resourceAcl = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://some.pod/group#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+
+    const groupAccess = unstable_getGroupResourceAccessOne(
+      resourceAcl,
+      "https://some-other.pod/group#webId"
+    );
+
+    expect(groupAccess).toEqual({
+      read: false,
+      append: false,
+      write: false,
+      control: false,
+    });
+  });
+
+  it("ignores ACL rules that apply to a different Group", () => {
+    let resourceAcl = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://some-other.pod/group#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+    resourceAcl = addAclRuleQuads(
+      resourceAcl,
+      "https://some.pod/group#webId",
+      "https://arbitrary.pod/resource",
+      { read: false, append: true, write: false, control: false },
+      "resource"
+    );
+
+    const groupAccess = unstable_getGroupResourceAccessOne(
+      resourceAcl,
+      "https://some.pod/group#webId"
+    );
+
+    expect(groupAccess).toEqual({
+      read: false,
+      append: true,
+      write: false,
+      control: false,
+    });
+  });
+
+  it("ignores ACL rules that apply to a different Resource", () => {
+    let resourceAcl = addAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://arbitrary.pod/group#webId",
+      "https://some-other.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+    resourceAcl = addAclRuleQuads(
+      resourceAcl,
+      "https://arbitrary.pod/group#webId",
+      "https://some.pod/resource",
+      { read: false, append: true, write: false, control: false },
+      "resource"
+    );
+
+    const groupAccess = unstable_getGroupResourceAccessOne(
+      resourceAcl,
+      "https://arbitrary.pod/group#webId"
+    );
+
+    expect(groupAccess).toEqual({
+      read: false,
+      append: true,
+      write: false,
+      control: false,
+    });
+  });
+});
+
+describe("getGroupResourceAccessAll", () => {
+  it("returns the applicable Access Modes for all Groups for whom Access Modes have been defined", () => {
+    let resourceAcl = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://some-other.pod/group#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+    resourceAcl = addAclRuleQuads(
+      resourceAcl,
+      "https://some.pod/group#webId",
+      "https://arbitrary.pod/resource",
+      { read: false, append: true, write: false, control: false },
+      "resource"
+    );
+
+    const groupAccess = unstable_getGroupResourceAccessAll(resourceAcl);
+
+    expect(groupAccess).toEqual({
+      "https://some.pod/group#webId": {
+        read: false,
+        append: true,
+        write: false,
+        control: false,
+      },
+      "https://some-other.pod/group#webId": {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      },
+    });
+  });
+
+  it("combines Access Modes defined for the same Groups in different Rules", () => {
+    let resourceAcl = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://some.pod/group#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+    resourceAcl = addAclRuleQuads(
+      resourceAcl,
+      "https://some.pod/group#webId",
+      "https://arbitrary.pod/resource",
+      { read: false, append: true, write: false, control: false },
+      "resource"
+    );
+
+    const groupAccess = unstable_getGroupResourceAccessAll(resourceAcl);
+
+    expect(groupAccess).toEqual({
+      "https://some.pod/group#webId": {
+        read: true,
+        append: true,
+        write: false,
+        control: false,
+      },
+    });
+  });
+
+  it("returns Access Modes for all Groups even if they are assigned in the same Rule", () => {
+    let resourceAcl = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://some.pod/group#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+    const oneQuad = Array.from(resourceAcl)[0];
+    resourceAcl.add(
+      DataFactory.quad(
+        oneQuad.subject,
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agentGroup"),
+        DataFactory.namedNode("https://some-other.pod/group#webId")
+      )
+    );
+
+    const agentAccess = unstable_getGroupResourceAccessAll(resourceAcl);
+
+    expect(agentAccess).toEqual({
+      "https://some.pod/group#webId": {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      },
+      "https://some-other.pod/group#webId": {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      },
+    });
+  });
+
+  it("ignores ACL rules that do not apply to a Group", () => {
+    let resourceAcl = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://some.pod/group#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+    const agentClassRuleSubjectIri = "#arbitrary-agent-rule";
+    resourceAcl.add(
+      DataFactory.quad(
+        DataFactory.namedNode(agentClassRuleSubjectIri),
+        DataFactory.namedNode(
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        ),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Authorization")
+      )
+    );
+    resourceAcl.add(
+      DataFactory.quad(
+        DataFactory.namedNode(agentClassRuleSubjectIri),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#accessTo"),
+        DataFactory.namedNode("https://arbitrary.pod/resource")
+      )
+    );
+    resourceAcl.add(
+      DataFactory.quad(
+        DataFactory.namedNode(agentClassRuleSubjectIri),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agent"),
+        DataFactory.namedNode("https://some.pod/agent#webId")
+      )
+    );
+
+    const groupAccess = unstable_getGroupResourceAccessAll(resourceAcl);
+
+    expect(groupAccess).toEqual({
+      "https://some.pod/group#webId": {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      },
+    });
+  });
+
+  it("ignores ACL rules that apply to a different Resource", () => {
+    let resourceAcl = addAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://arbitrary.pod/group#webId",
+      "https://some-other.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+    resourceAcl = addAclRuleQuads(
+      resourceAcl,
+      "https://some.pod/group#webId",
+      "https://some.pod/resource",
+      { read: false, append: true, write: false, control: false },
+      "resource"
+    );
+
+    const groupAccess = unstable_getGroupResourceAccessAll(resourceAcl);
+
+    expect(groupAccess).toEqual({
+      "https://some.pod/group#webId": {
+        read: false,
+        append: true,
+        write: false,
+        control: false,
+      },
+    });
+  });
+});
+
+describe("getGroupDefaultAccessOne", () => {
+  it("returns the applicable Access Modes for a single Group", () => {
+    const containerAcl = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some.pod/group#webId",
+      "https://arbitrary.pod/container/",
+      { read: true, append: false, write: false, control: true },
+      "default"
+    );
+
+    const groupAccess = unstable_getGroupDefaultAccessOne(
+      containerAcl,
+      "https://some.pod/group#webId"
+    );
+
+    expect(groupAccess).toEqual({
+      read: true,
+      append: false,
+      write: false,
+      control: true,
+    });
+  });
+
+  it("combines Access Modes defined for a given Group in separate rules", () => {
+    let containerAcl = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some.pod/group#webId",
+      "https://arbitrary.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "default"
+    );
+    containerAcl = addAclRuleQuads(
+      containerAcl,
+      "https://some.pod/group#webId",
+      "https://arbitrary.pod/container/",
+      { read: false, append: true, write: false, control: false },
+      "default"
+    );
+
+    const groupAccess = unstable_getGroupDefaultAccessOne(
+      containerAcl,
+      "https://some.pod/group#webId"
+    );
+
+    expect(groupAccess).toEqual({
+      read: true,
+      append: true,
+      write: false,
+      control: false,
+    });
+  });
+
+  it("returns false for all Access Modes if there are no ACL rules for the given Group", () => {
+    const containerAcl = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some.pod/group#webId",
+      "https://arbitrary.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "default"
+    );
+
+    const groupAccess = unstable_getGroupDefaultAccessOne(
+      containerAcl,
+      "https://some-other.pod/group#webId"
+    );
+
+    expect(groupAccess).toEqual({
+      read: false,
+      append: false,
+      write: false,
+      control: false,
+    });
+  });
+
+  it("ignores ACL rules that apply to a different Group", () => {
+    let containerAcl = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some-other.pod/group#webId",
+      "https://arbitrary.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "default"
+    );
+    containerAcl = addAclRuleQuads(
+      containerAcl,
+      "https://some.pod/group#webId",
+      "https://arbitrary.pod/container/",
+      { read: false, append: true, write: false, control: false },
+      "default"
+    );
+
+    const groupAccess = unstable_getGroupDefaultAccessOne(
+      containerAcl,
+      "https://some.pod/group#webId"
+    );
+
+    expect(groupAccess).toEqual({
+      read: false,
+      append: true,
+      write: false,
+      control: false,
+    });
+  });
+
+  it("ignores ACL rules that apply to a different Resource", () => {
+    let containerAcl = addAclRuleQuads(
+      getMockDataset("https://some.pod/container/.acl"),
+      "https://arbitrary.pod/group#webId",
+      "https://some-other.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "default"
+    );
+    containerAcl = addAclRuleQuads(
+      containerAcl,
+      "https://arbitrary.pod/group#webId",
+      "https://some.pod/container/",
+      { read: false, append: true, write: false, control: false },
+      "default"
+    );
+
+    const groupAccess = unstable_getGroupDefaultAccessOne(
+      containerAcl,
+      "https://arbitrary.pod/group#webId"
+    );
+
+    expect(groupAccess).toEqual({
+      read: false,
+      append: true,
+      write: false,
+      control: false,
+    });
+  });
+});
+
+describe("getGroupDefaultAccessAll", () => {
+  it("returns the applicable Access Modes for all Groups for whom Access Modes have been defined", () => {
+    let containerAcl = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some-other.pod/group#webId",
+      "https://arbitrary.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "default"
+    );
+    containerAcl = addAclRuleQuads(
+      containerAcl,
+      "https://some.pod/group#webId",
+      "https://arbitrary.pod/container/",
+      { read: false, append: true, write: false, control: false },
+      "default"
+    );
+
+    const groupAccess = unstable_getGroupDefaultAccessAll(containerAcl);
+
+    expect(groupAccess).toEqual({
+      "https://some.pod/group#webId": {
+        read: false,
+        append: true,
+        write: false,
+        control: false,
+      },
+      "https://some-other.pod/group#webId": {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      },
+    });
+  });
+
+  it("combines Access Modes defined for the same Group in different Rules", () => {
+    let containerAcl = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some.pod/group#webId",
+      "https://arbitrary.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "default"
+    );
+    containerAcl = addAclRuleQuads(
+      containerAcl,
+      "https://some.pod/group#webId",
+      "https://arbitrary.pod/container/",
+      { read: false, append: true, write: false, control: false },
+      "default"
+    );
+
+    const groupAccess = unstable_getGroupDefaultAccessAll(containerAcl);
+
+    expect(groupAccess).toEqual({
+      "https://some.pod/group#webId": {
+        read: true,
+        append: true,
+        write: false,
+        control: false,
+      },
+    });
+  });
+
+  it("returns Access Modes for all Groups even if they are assigned in the same Rule", () => {
+    let containerAcl = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acln"),
+      "https://some.pod/group#webId",
+      "https://arbitrary.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "default"
+    );
+    const oneQuad = Array.from(containerAcl)[0];
+    containerAcl.add(
+      DataFactory.quad(
+        oneQuad.subject,
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agentGroup"),
+        DataFactory.namedNode("https://some-other.pod/group#webId")
+      )
+    );
+
+    const groupAccess = unstable_getGroupDefaultAccessAll(containerAcl);
+
+    expect(groupAccess).toEqual({
+      "https://some.pod/group#webId": {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      },
+      "https://some-other.pod/group#webId": {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      },
+    });
+  });
+
+  it("ignores ACL rules that do not apply to a Group", () => {
+    let containerAcl = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some.pod/group#webId",
+      "https://arbitrary.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "default"
+    );
+    const agentClassRuleSubjectIri = "#arbitrary-agent-rule";
+    containerAcl.add(
+      DataFactory.quad(
+        DataFactory.namedNode(agentClassRuleSubjectIri),
+        DataFactory.namedNode(
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        ),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Authorization")
+      )
+    );
+    containerAcl.add(
+      DataFactory.quad(
+        DataFactory.namedNode(agentClassRuleSubjectIri),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#default"),
+        DataFactory.namedNode("https://arbitrary.pod/container/")
+      )
+    );
+    containerAcl.add(
+      DataFactory.quad(
+        DataFactory.namedNode(agentClassRuleSubjectIri),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agent"),
+        DataFactory.namedNode("https://some.pod/agent#webId")
+      )
+    );
+
+    const groupAccess = unstable_getGroupDefaultAccessAll(containerAcl);
+
+    expect(groupAccess).toEqual({
+      "https://some.pod/group#webId": {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      },
+    });
+  });
+
+  it("ignores ACL rules that apply to a different Resource", () => {
+    let containerAcl = addAclRuleQuads(
+      getMockDataset("https://some.pod/container/.acl"),
+      "https://arbitrary.pod/group#webId",
+      "https://some-other.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "default"
+    );
+    containerAcl = addAclRuleQuads(
+      containerAcl,
+      "https://some.pod/group#webId",
+      "https://some.pod/container/",
+      { read: false, append: true, write: false, control: false },
+      "default"
+    );
+
+    const groupAccess = unstable_getGroupDefaultAccessAll(containerAcl);
+
+    expect(groupAccess).toEqual({
+      "https://some.pod/group#webId": {
+        read: false,
+        append: true,
+        write: false,
+        control: false,
+      },
+    });
+  });
+});

--- a/src/acl/group.test.ts
+++ b/src/acl/group.test.ts
@@ -41,7 +41,7 @@ import {
 
 function addAclRuleQuads(
   aclDataset: LitDataset & WithResourceInfo,
-  group: WebId,
+  group: IriString,
   resource: IriString,
   access: unstable_Access,
   type: "resource" | "default"

--- a/src/acl/group.ts
+++ b/src/acl/group.ts
@@ -47,7 +47,7 @@ import { acl } from "../constants";
 /**
  * Find out what Access Modes have been granted to a given Group of agents specifically for a given Resource.
  *
- * Keep in mind that this function will not tell you what access the given Group has through other ACL rules, e.g. public permissions.
+ * Keep in mind that this function will not tell you what access members of the given Group have through other ACL rules, e.g. public permissions.
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
@@ -77,7 +77,7 @@ export function unstable_getGroupAccessOne(
 /**
  * Find out what Access Modes have been granted to specific Groups of agents for a given Resource.
  *
- * Keep in mind that this function will not tell you what access each Group has through other ACL rules, e.g. public permissions.
+ * Keep in mind that this function will not tell you what access members of each Group have through other ACL rules, e.g. public permissions.
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
@@ -102,8 +102,8 @@ export function unstable_getGroupAccessAll(
  * Given an ACL LitDataset, find out which access modes it provides to a Group for its associated Resource.
  *
  * Keep in mind that this function will not tell you:
- * - what access the given Group has through other ACL rules, e.g. public permissions.
- * - what access the given Group has to child Resources, in case the associated Resource is a Container (see [[unstable_getGroupDefaultAccessModesOne]] for that).
+ * - what access members of the given Group have through other ACL rules, e.g. public permissions.
+ * - what access members of the given Group have to child Resources, in case the associated Resource is a Container (see [[unstable_getGroupDefaultAccessModesOne]] for that).
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
@@ -129,8 +129,8 @@ export function unstable_getGroupResourceAccessOne(
  * Given an ACL LitDataset, find out which access modes it provides to specific Groups for the associated Resource.
  *
  * Keep in mind that this function will not tell you:
- * - what access arbitrary Groups might have been given through other ACL rules, e.g. public permissions.
- * - what access arbitrary Groups have to child Resources, in case the associated Resource is a Container.
+ * - what access arbitrary members of these Groups might have been given through other ACL rules, e.g. public permissions.
+ * - what access arbitrary members of these Groups have to child Resources, in case the associated Resource is a Container.
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
@@ -152,8 +152,8 @@ export function unstable_getGroupResourceAccessAll(
  * Given an ACL LitDataset, find out which access modes it provides to a given Group for the associated Container Resource's child Resources.
  *
  * Keep in mind that this function will not tell you:
- * - what access the given Group has through other ACL rules, e.g. public permissions.
- * - what access the given Group has to the Container Resource itself (see [[unstable_getGroupResourceAccessOne]] for that).
+ * - what access members of the given Group have through other ACL rules, e.g. public permissions.
+ * - what access members of the given Group have to the Container Resource itself (see [[unstable_getGroupResourceAccessOne]] for that).
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
@@ -179,8 +179,8 @@ export function unstable_getGroupDefaultAccessOne(
  * Given an ACL LitDataset, find out which access modes it provides to specific Groups for the associated Container Resource's child Resources.
  *
  * Keep in mind that this function will not tell you:
- * - what access arbitrary Groups have through other ACL rules, e.g. public permissions.
- * - what access arbitrary Groups have to the Container Resource itself (see [[unstable_getGroupResourceAccessAll]] for that).
+ * - what access arbitrary members of these Groups have through other ACL rules, e.g. public permissions.
+ * - what access arbitrary members of these Groups have to the Container Resource itself (see [[unstable_getGroupResourceAccessAll]] for that).
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *

--- a/src/acl/group.ts
+++ b/src/acl/group.ts
@@ -38,12 +38,10 @@ import {
   unstable_hasFallbackAcl,
   unstable_getResourceAcl,
   unstable_getFallbackAcl,
+  internal_getAclRulesForIri,
+  internal_getAccessByIri,
 } from "../acl";
-import {
-  getAclRulesForIri,
-  unstable_AgentAccess,
-  getAccessByIri,
-} from "./agent";
+
 import { acl } from "../constants";
 
 /**
@@ -88,7 +86,7 @@ export function unstable_getGroupAccessOne(
  */
 export function unstable_getGroupAccessAll(
   resourceInfo: unstable_WithAcl & WithResourceInfo
-): unstable_AgentAccess | null {
+): Record<IriString, unstable_Access> | null {
   if (unstable_hasResourceAcl(resourceInfo)) {
     const resourceAcl = unstable_getResourceAcl(resourceInfo);
     return unstable_getGroupResourceAccessAll(resourceAcl);
@@ -204,9 +202,11 @@ function getGroupAclRuleForGroup(
   rules: unstable_AclRule[],
   group: UrlString
 ): unstable_AclRule[] {
-  return getAclRulesForIri(rules, group, acl.agentGroup);
+  return internal_getAclRulesForIri(rules, group, acl.agentGroup);
 }
 
-function getAccessByGroup(aclRules: unstable_AclRule[]): unstable_AgentAccess {
-  return getAccessByIri(aclRules, acl.agentGroup);
+function getAccessByGroup(
+  aclRules: unstable_AclRule[]
+): Record<IriString, unstable_Access> {
+  return internal_getAccessByIri(aclRules, acl.agentGroup);
 }

--- a/src/acl/group.ts
+++ b/src/acl/group.ts
@@ -1,0 +1,212 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {
+  unstable_AclDataset,
+  unstable_Access,
+  unstable_AclRule,
+  unstable_WithAcl,
+  WithResourceInfo,
+  IriString,
+  UrlString,
+} from "../interfaces";
+import {
+  internal_getAclRules,
+  internal_getDefaultAclRulesForResource,
+  internal_getAccess,
+  internal_combineAccessModes,
+  internal_getResourceAclRulesForResource,
+  unstable_hasResourceAcl,
+  unstable_hasFallbackAcl,
+  unstable_getResourceAcl,
+  unstable_getFallbackAcl,
+} from "../acl";
+import {
+  getAclRulesForIri,
+  unstable_AgentAccess,
+  getAccessByIri,
+} from "./agent";
+import { acl } from "../constants";
+
+/**
+ * Find out what Access Modes have been granted to a given Group of agents specifically for a given Resource.
+ *
+ * Keep in mind that this function will not tell you what access the given Group has through other ACL rules, e.g. public permissions.
+ *
+ * Also, please note that this function is still experimental: its API can change in non-major releases.
+ *
+ * @param resourceInfo Information about the Resource to which the given Group may have been granted access.
+ * @param group URL of the Group for which to retrieve what access it has to the Resource.
+ * @returns Which Access Modes have been granted to the Group specifically for the given Resource, or `null` if it could not be determined (e.g. because the current user does not have Control Access to a given Resource or its Container).
+ */
+export function unstable_getGroupAccessOne(
+  resourceInfo: unstable_WithAcl & WithResourceInfo,
+  group: UrlString
+): unstable_Access | null {
+  if (unstable_hasResourceAcl(resourceInfo)) {
+    return unstable_getGroupResourceAccessOne(
+      resourceInfo.acl.resourceAcl,
+      group
+    );
+  }
+  if (unstable_hasFallbackAcl(resourceInfo)) {
+    return unstable_getGroupDefaultAccessOne(
+      resourceInfo.acl.fallbackAcl,
+      group
+    );
+  }
+  return null;
+}
+
+/**
+ * Find out what Access Modes have been granted to specific Groups of agents for a given Resource.
+ *
+ * Keep in mind that this function will not tell you what access each Group has through other ACL rules, e.g. public permissions.
+ *
+ * Also, please note that this function is still experimental: its API can change in non-major releases.
+ *
+ * @param resourceInfo Information about the Resource to which the given Group may have been granted access.
+ * @returns Which Access Modes have been granted to which Groups specifically for the given Resource, or `null` if it could not be determined (e.g. because the current user does not have Control Access to a given Resource or its Container).
+ */
+export function unstable_getGroupAccessAll(
+  resourceInfo: unstable_WithAcl & WithResourceInfo
+): unstable_AgentAccess | null {
+  if (unstable_hasResourceAcl(resourceInfo)) {
+    const resourceAcl = unstable_getResourceAcl(resourceInfo);
+    return unstable_getGroupResourceAccessAll(resourceAcl);
+  }
+  if (unstable_hasFallbackAcl(resourceInfo)) {
+    const fallbackAcl = unstable_getFallbackAcl(resourceInfo);
+    return unstable_getGroupDefaultAccessAll(fallbackAcl);
+  }
+  return null;
+}
+
+/**
+ * Given an ACL LitDataset, find out which access modes it provides to a Group for its associated Resource.
+ *
+ * Keep in mind that this function will not tell you:
+ * - what access the given Group has through other ACL rules, e.g. public permissions.
+ * - what access the given Group has to child Resources, in case the associated Resource is a Container (see [[unstable_getGroupDefaultAccessModesOne]] for that).
+ *
+ * Also, please note that this function is still experimental: its API can change in non-major releases.
+ *
+ * @param aclDataset The LitDataset that contains Access-Control List rules.
+ * @param group URL of the Group for which to retrieve what access it has to the Resource.
+ * @returns Which Access Modes have been granted to the Group specifically for the Resource the given ACL LitDataset is associated with.
+ */
+export function unstable_getGroupResourceAccessOne(
+  aclDataset: unstable_AclDataset,
+  group: UrlString
+): unstable_Access {
+  const allRules = internal_getAclRules(aclDataset);
+  const resourceRules = internal_getResourceAclRulesForResource(
+    allRules,
+    aclDataset.accessTo
+  );
+  const groupResourceRules = getGroupAclRuleForGroup(resourceRules, group);
+  const groupAccessModes = groupResourceRules.map(internal_getAccess);
+  return internal_combineAccessModes(groupAccessModes);
+}
+
+/**
+ * Given an ACL LitDataset, find out which access modes it provides to specific Groups for the associated Resource.
+ *
+ * Keep in mind that this function will not tell you:
+ * - what access arbitrary Groups might have been given through other ACL rules, e.g. public permissions.
+ * - what access arbitrary Groups have to child Resources, in case the associated Resource is a Container.
+ *
+ * Also, please note that this function is still experimental: its API can change in non-major releases.
+ *
+ * @param aclDataset The LitDataset that contains Access-Control List rules.
+ * @returns Which Access Modes have been granted to which Groups specifically for the Resource the given ACL LitDataset is associated with.
+ */
+export function unstable_getGroupResourceAccessAll(
+  aclDataset: unstable_AclDataset
+): Record<UrlString, unstable_Access> {
+  const allRules = internal_getAclRules(aclDataset);
+  const resourceRules = internal_getResourceAclRulesForResource(
+    allRules,
+    aclDataset.accessTo
+  );
+  return getAccessByGroup(resourceRules);
+}
+
+/**
+ * Given an ACL LitDataset, find out which access modes it provides to a given Group for the associated Container Resource's child Resources.
+ *
+ * Keep in mind that this function will not tell you:
+ * - what access the given Group has through other ACL rules, e.g. public permissions.
+ * - what access the given Group has to the Container Resource itself (see [[unstable_getGroupResourceAccessOne]] for that).
+ *
+ * Also, please note that this function is still experimental: its API can change in non-major releases.
+ *
+ * @param aclDataset The LitDataset that contains Access-Control List rules for a certain Container.
+ * @param group URL of the Group for which to retrieve what access it has to the child Resources of the given Container.
+ * @returns Which Access Modes have been granted to the Group specifically for the children of the Container associated with the given ACL LitDataset.
+ */
+export function unstable_getGroupDefaultAccessOne(
+  aclDataset: unstable_AclDataset,
+  group: UrlString
+): unstable_Access {
+  const allRules = internal_getAclRules(aclDataset);
+  const defaultRules = internal_getDefaultAclRulesForResource(
+    allRules,
+    aclDataset.accessTo
+  );
+  const groupDefaultRules = getGroupAclRuleForGroup(defaultRules, group);
+  const groupAccessModes = groupDefaultRules.map(internal_getAccess);
+  return internal_combineAccessModes(groupAccessModes);
+}
+
+/**
+ * Given an ACL LitDataset, find out which access modes it provides to specific Groups for the associated Container Resource's child Resources.
+ *
+ * Keep in mind that this function will not tell you:
+ * - what access arbitrary Groups have through other ACL rules, e.g. public permissions.
+ * - what access arbitrary Groups have to the Container Resource itself (see [[unstable_getGroupResourceAccessAll]] for that).
+ *
+ * Also, please note that this function is still experimental: its API can change in non-major releases.
+ *
+ * @param aclDataset The LitDataset that contains Access-Control List rules for a certain Container.
+ * @returns Which Access Modes have been granted to which Groups specifically for the children of the Container associated with the given ACL LitDataset.
+ */
+export function unstable_getGroupDefaultAccessAll(
+  aclDataset: unstable_AclDataset
+): Record<UrlString, unstable_Access> {
+  const allRules = internal_getAclRules(aclDataset);
+  const defaultRules = internal_getDefaultAclRulesForResource(
+    allRules,
+    aclDataset.accessTo
+  );
+  return getAccessByGroup(defaultRules);
+}
+
+function getGroupAclRuleForGroup(
+  rules: unstable_AclRule[],
+  group: UrlString
+): unstable_AclRule[] {
+  return getAclRulesForIri(rules, group, acl.agentGroup);
+}
+
+function getAccessByGroup(aclRules: unstable_AclRule[]): unstable_AgentAccess {
+  return getAccessByIri(aclRules, acl.agentGroup);
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -110,6 +110,12 @@ import {
   unstable_getPublicResourceAccess,
   unstable_getPublicDefaultAccess,
   unstable_hasAccessibleAcl,
+  unstable_getGroupAccessOne,
+  unstable_getGroupAccessAll,
+  unstable_getGroupResourceAccessOne,
+  unstable_getGroupResourceAccessAll,
+  unstable_getGroupDefaultAccessOne,
+  unstable_getGroupDefaultAccessAll,
   // Deprecated functions still exported for backwards compatibility:
   getStringUnlocalizedOne,
   getStringUnlocalizedAll,
@@ -216,6 +222,12 @@ it("exports the public API from the entry file", () => {
   expect(unstable_getPublicResourceAccess).toBeDefined();
   expect(unstable_getPublicDefaultAccess).toBeDefined();
   expect(unstable_hasAccessibleAcl).toBeDefined();
+  expect(unstable_getGroupAccessOne).toBeDefined();
+  expect(unstable_getGroupAccessAll).toBeDefined();
+  expect(unstable_getGroupResourceAccessOne).toBeDefined();
+  expect(unstable_getGroupResourceAccessAll).toBeDefined();
+  expect(unstable_getGroupDefaultAccessOne).toBeDefined();
+  expect(unstable_getGroupDefaultAccessAll).toBeDefined();
 });
 
 it("still exports deprecated methods", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,14 @@ export {
   unstable_setAgentDefaultAccess,
 } from "./acl/agent";
 export {
+  unstable_getGroupAccessOne,
+  unstable_getGroupAccessAll,
+  unstable_getGroupResourceAccessOne,
+  unstable_getGroupResourceAccessAll,
+  unstable_getGroupDefaultAccessOne,
+  unstable_getGroupDefaultAccessAll,
+} from "./acl/group";
+export {
   unstable_getPublicAccess,
   unstable_getPublicResourceAccess,
   unstable_getPublicDefaultAccess,


### PR DESCRIPTION
# New feature description

This adds the ability to read Group permissions, be it for a given Resource or for the child Resources of a given Container.
Permissions may be read for a given Group, or for all Groups that have explicitly been granted access rights in the target Resource's ACL document.

# Checklist

- [X] All acceptance criteria are met.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
