### PR TITLE
Aligns fetchFile with fetchDataset

### DIFF
--- a/src/acl.ts
+++ b/src/acl.ts
@@ -25,6 +25,7 @@ import {
   fetchLitDataset,
   defaultFetchOptions,
   internal_fetchResourceInfo,
+  getFetchedFrom,
 } from "./litDataset";
 import {
   WithResourceInfo,
@@ -61,7 +62,7 @@ export async function internal_fetchResourceAcl(
       options
     );
     return Object.assign(aclLitDataset, {
-      accessTo: dataset.resourceInfo.fetchedFrom,
+      accessTo: getFetchedFrom(dataset),
     });
   } catch (e) {
     // Since a Solid server adds a `Link` header to an ACL even if that ACL does not exist,
@@ -76,7 +77,7 @@ export async function internal_fetchFallbackAcl(
   resource: unstable_WithAccessibleAcl,
   options: Partial<typeof defaultFetchOptions> = defaultFetchOptions
 ): Promise<unstable_AclDataset | null> {
-  const resourceUrl = new URL(resource.resourceInfo.fetchedFrom);
+  const resourceUrl = new URL(getFetchedFrom(resource));
   const resourcePath = resourceUrl.pathname;
   // Note: we're currently assuming that the Origin is the root of the Pod. However, it is not yet
   //       set in stone that that will always be the case. We might need to check the Container's
@@ -144,9 +145,9 @@ export function unstable_hasResourceAcl<
   unstable_WithAccessibleAcl {
   return (
     resource.acl.resourceAcl !== null &&
-    resource.resourceInfo.fetchedFrom === resource.acl.resourceAcl.accessTo &&
+    getFetchedFrom(resource) === resource.acl.resourceAcl.accessTo &&
     resource.resourceInfo.unstable_aclUrl ===
-      resource.acl.resourceAcl.resourceInfo.fetchedFrom
+      getFetchedFrom(resource.acl.resourceAcl)
   );
 }
 
@@ -228,7 +229,7 @@ export function unstable_createAclFromFallbackAcl(
     unstable_WithAccessibleAcl
 ): unstable_AclDataset {
   const emptyResourceAcl: unstable_AclDataset = Object.assign(dataset(), {
-    accessTo: resource.resourceInfo.fetchedFrom,
+    accessTo: getFetchedFrom(resource),
     resourceInfo: {
       fetchedFrom: resource.resourceInfo.unstable_aclUrl,
       isLitDataset: true,
@@ -242,7 +243,7 @@ export function unstable_createAclFromFallbackAcl(
   );
   const resourceAclRules = defaultAclRules.map((rule) => {
     rule = removeAll(rule, acl.default);
-    rule = setIri(rule, acl.accessTo, resource.resourceInfo.fetchedFrom);
+    rule = setIri(rule, acl.accessTo, getFetchedFrom(resource));
     return rule;
   });
 

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -29,6 +29,7 @@ import {
   setStringNoLocale,
   saveLitDatasetAt,
   isLitDataset,
+  getContentType,
   unstable_fetchResourceInfoWithAcl,
   unstable_fetchLitDatasetWithAcl,
   unstable_hasResourceAcl,
@@ -44,6 +45,7 @@ import {
   unstable_createAclFromFallbackAcl,
   unstable_getPublicDefaultAccess,
   unstable_getPublicResourceAccess,
+  unstable_fetchFile,
 } from "./index";
 
 describe("End-to-end tests", () => {
@@ -194,5 +196,16 @@ describe("End-to-end tests", () => {
         unstable_getPublicResourceAccess(newResourceAcl)
       );
     }
+  });
+
+  it("can fetch a non-RDF file and its metadata", async () => {
+    const jsonFile = await unstable_fetchFile(
+      "https://lit-e2e-test.inrupt.net/public/arbitrary.json"
+    );
+
+    expect(getContentType(jsonFile)).toEqual("application/json");
+
+    const data = JSON.parse(await jsonFile.text());
+    expect(data).toEqual({ arbitrary: "json data" });
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -30,6 +30,7 @@ import {
   isContainer,
   isLitDataset,
   getContentType,
+  getFetchedFrom,
   saveLitDatasetAt,
   saveLitDatasetInContainer,
   unstable_saveAclFor,
@@ -128,6 +129,7 @@ import {
   setStringInLocale,
   removeStringInLocale,
 } from "./index";
+import { expects } from "rdf-namespaces/dist/hydra";
 
 // These tests aren't too useful in preventing bugs, but they work around this issue:
 // https://github.com/facebook/jest/issues/10032
@@ -142,6 +144,7 @@ it("exports the public API from the entry file", () => {
   expect(isContainer).toBeDefined();
   expect(isLitDataset).toBeDefined();
   expect(getContentType).toBeDefined();
+  expect(getFetchedFrom).toBeDefined();
   expect(saveLitDatasetAt).toBeDefined();
   expect(saveLitDatasetInContainer).toBeDefined();
   expect(unstable_saveAclFor).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export {
   isContainer,
   isLitDataset,
   getContentType,
+  getFetchedFrom,
   saveLitDatasetAt,
   saveLitDatasetInContainer,
   unstable_fetchLitDatasetWithAcl,

--- a/src/litDataset.ts
+++ b/src/litDataset.ts
@@ -219,7 +219,7 @@ export function parseResourceInfo(
  * @returns Whether `resource` is a Container.
  */
 export function isContainer(resource: WithResourceInfo): boolean {
-  return resource.resourceInfo.fetchedFrom.endsWith("/");
+  return getFetchedFrom(resource).endsWith("/");
 }
 
 /**
@@ -238,6 +238,10 @@ export function getContentType(resource: WithResourceInfo): string | null {
   return resource.resourceInfo.contentType ?? null;
 }
 
+/**
+ * @param resource
+ * @returns The URL from which the resource has been fetched
+ */
 export function getFetchedFrom(resource: WithResourceInfo): string {
   return resource.resourceInfo.fetchedFrom;
 }
@@ -467,7 +471,7 @@ export async function unstable_saveAclFor(
   );
   const savedAclDataset: unstable_AclDataset &
     typeof savedDataset = Object.assign(savedDataset, {
-    accessTo: resource.resourceInfo.fetchedFrom,
+    accessTo: getFetchedFrom(resource),
   });
 
   return savedAclDataset;
@@ -531,7 +535,7 @@ function getNamedNodeFromLocalNode(localNode: LocalNode): NamedNode {
 function resolveLocalIrisInLitDataset<
   Dataset extends LitDataset & WithResourceInfo
 >(litDataset: Dataset): Dataset {
-  const resourceIri = litDataset.resourceInfo.fetchedFrom;
+  const resourceIri = getFetchedFrom(litDataset);
   const unresolvedQuads = Array.from(litDataset);
 
   unresolvedQuads.forEach((unresolvedQuad) => {

--- a/src/litDataset.ts
+++ b/src/litDataset.ts
@@ -238,6 +238,10 @@ export function getContentType(resource: WithResourceInfo): string | null {
   return resource.resourceInfo.contentType ?? null;
 }
 
+export function getFetchedFrom(resource: WithResourceInfo): string {
+  return resource.resourceInfo.fetchedFrom;
+}
+
 /**
  * Experimental: fetch a LitDataset and its associated Access Control List.
  *

--- a/src/thing.ts
+++ b/src/thing.ts
@@ -46,6 +46,7 @@ import {
   unstable_AclDataset,
 } from "./interfaces";
 import { internal_isAclDataset } from "./acl";
+import { getFetchedFrom } from "./litDataset";
 
 /**
  * @hidden Scopes are not yet consistently used in Solid and hence not properly implemented in this library yet (the add*() and set*() functions do not respect it yet), so we're not exposing these to developers at this point in time.
@@ -170,7 +171,7 @@ export function removeThing<Dataset extends LitDataset>(
 ): Dataset & WithChangeLog {
   const newLitDataset = withChangeLog(cloneLitStructs(litDataset));
   const resourceIri: UrlString | undefined = hasResourceInfo(newLitDataset)
-    ? newLitDataset.resourceInfo.fetchedFrom
+    ? getFetchedFrom(newLitDataset)
     : undefined;
 
   const thingSubject = toNode(thing);

--- a/website/docs/tutorials/working-with-files.md
+++ b/website/docs/tutorials/working-with-files.md
@@ -25,18 +25,21 @@ Reading a file is just a matter of fetching the content available at a certain U
 the fetched file as a blob. It is then up to you to decode it appropriately.
 
 ```typescript
-import { unstable_fetchFile } from "lit-solid";
+import {
+  unstable_fetchFile,
+  isLitDataset,
+  getContentType,
+  getFetchedFrom,
+} from "lit-solid";
 
 const file = await unstable_fetchFile(
   "https://example.com/some/interesting/file"
 );
 // file is a Blob (see https://developer.mozilla.org/en-US/docs/Web/API/Blob)
 console.log(
-  `Fetched a ${file.resourceInfo.contentType} file from ${file.resourceInfo.fetchedFrom}.`
+  `Fetched a ${getContentType(file)} file from ${getFetchedFrom(file)}.`
 );
-console.log(
-  `The file is ${file.resourceInfo.isLitDataset ? "" : "not "}a dataset.`
-);
+console.log(`The file is ${isLitDataset(file) ? "" : "not "}a dataset.`);
 ```
 
 ## Deleting a file

--- a/website/docs/tutorials/working-with-files.md
+++ b/website/docs/tutorials/working-with-files.md
@@ -27,12 +27,16 @@ the fetched file as a blob. It is then up to you to decode it appropriately.
 ```typescript
 import { unstable_fetchFile } from "lit-solid";
 
-const response = await unstable_fetchFile(
+const file = await unstable_fetchFile(
   "https://example.com/some/interesting/file"
 );
-if (response.ok) {
-  const myFile = await response.blob();
-}
+// file is a Blob (see https://developer.mozilla.org/en-US/docs/Web/API/Blob)
+console.log(
+  `Fetched a ${file.resourceInfo.contentType} file from ${file.resourceInfo.fetchedFrom}.`
+);
+console.log(
+  `The file is ${file.resourceInfo.isLitDataset ? "" : "not "}a dataset.`
+);
 ```
 
 ## Deleting a file


### PR DESCRIPTION
Fixes #219, #152. 

Instead of returning a Response that the developer has to parse, this returns the same types as fetchLitDataset. This does not change deleting and writing non-RDF data (will do in a future PR).

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
