### PR TITLE
Skeleton for LDN notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@ First release! What's possible with this first release:
 - Manipulate data in datasets.
 - Inspect a user's, group's and public permissions w.r.t. a given Resource or child Resources of a Container. (Experimental.)
 - Retrieve, delete and/or write any file (including non-RDF) from/to a Pod. (Experimental.)
+- Create and send an asynchronous notification

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -43,3 +43,8 @@ export const rdf = {
 export const foaf = {
   Agent: "http://xmlns.com/foaf/0.1/Agent",
 } as const;
+
+/** @internal */
+export const ldp = {
+  inbox: "https://www.w3.org/ns/ldp#inbox",
+} as const;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,3 +48,10 @@ export const foaf = {
 export const ldp = {
   inbox: "https://www.w3.org/ns/ldp#inbox",
 } as const;
+
+/** @internal */
+export const as = {
+  actor: "https://www.w3.org/ns/activitystreams#actor",
+  target: "https://www.w3.org/ns/activitystreams#target",
+  Event: "https://www.w3.org/ns/activitystreams#Event",
+} as const;

--- a/src/datatypes.ts
+++ b/src/datatypes.ts
@@ -237,7 +237,7 @@ export function asNamedNode(iri: Iri | IriString): NamedNode {
     return iri;
   }
   // If the runtime environment supports URL, instantiate one.
-  // If thte given IRI is not a valid URL, it will throw an error.
+  // If the given IRI is not a valid URL, it will throw an error.
   // See: https://developer.mozilla.org/en-US/docs/Web/API/URL
   /* istanbul ignore else [URL is available in our testing environment, so we cannot test the alternative] */
   if (typeof URL !== "undefined") {

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -179,7 +179,9 @@ describe("End-to-end tests", () => {
       });
       await unstable_saveAclFor(datasetWithAcl, cleanedAcl);
     }
-  });
+    // Fetching both Resource and Fallback ACLs takes quite a while on a bad network connection,
+    // so double Jest's default timeout of 5 seconds:
+  }, 10000);
 
   it("can copy default rules from the fallback ACL as Resource rules to a new ACL", async () => {
     const dataset = await unstable_fetchLitDatasetWithAcl(
@@ -196,7 +198,9 @@ describe("End-to-end tests", () => {
         unstable_getPublicResourceAccess(newResourceAcl)
       );
     }
-  });
+    // Fetching both Resource and Fallback ACLs takes quite a while on a bad network connection,
+    // so double Jest's default timeout of 5 seconds:
+  }, 10000);
 
   it("can fetch a non-RDF file and its metadata", async () => {
     const jsonFile = await unstable_fetchFile(

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -130,6 +130,9 @@ import {
   removeStringInLocale,
   unstable_discoverInbox,
   unstable_fetchInbox,
+  unstable_buildNotification,
+  unstable_sendNotification,
+  unstable_sendNotificationToInbox,
 } from "./index";
 
 // These tests aren't too useful in preventing bugs, but they work around this issue:
@@ -234,6 +237,9 @@ it("exports the public API from the entry file", () => {
   expect(unstable_getGroupDefaultAccessAll).toBeDefined();
   expect(unstable_discoverInbox).toBeDefined(),
     expect(unstable_fetchInbox).toBeDefined();
+  expect(unstable_buildNotification).toBeDefined();
+  expect(unstable_sendNotification).toBeDefined();
+  expect(unstable_sendNotificationToInbox).toBeDefined();
 });
 
 it("still exports deprecated methods", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -128,6 +128,8 @@ import {
   addStringInLocale,
   setStringInLocale,
   removeStringInLocale,
+  unstable_discoverInbox,
+  unstable_fetchInbox,
 } from "./index";
 import { expects } from "rdf-namespaces/dist/hydra";
 
@@ -231,6 +233,8 @@ it("exports the public API from the entry file", () => {
   expect(unstable_getGroupResourceAccessAll).toBeDefined();
   expect(unstable_getGroupDefaultAccessOne).toBeDefined();
   expect(unstable_getGroupDefaultAccessAll).toBeDefined();
+  expect(unstable_discoverInbox).toBeDefined(),
+    expect(unstable_fetchInbox).toBeDefined();
 });
 
 it("still exports deprecated methods", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -131,7 +131,6 @@ import {
   unstable_discoverInbox,
   unstable_fetchInbox,
 } from "./index";
-import { expects } from "rdf-namespaces/dist/hydra";
 
 // These tests aren't too useful in preventing bugs, but they work around this issue:
 // https://github.com/facebook/jest/issues/10032

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,6 +167,9 @@ export {
 export {
   unstable_discoverInbox,
   unstable_fetchInbox,
+  unstable_buildNotification,
+  unstable_sendNotification,
+  unstable_sendNotificationToInbox,
 } from "./notifications/ldn";
 export {
   Url,

--- a/src/index.ts
+++ b/src/index.ts
@@ -165,6 +165,10 @@ export {
   unstable_getPublicDefaultAccess,
 } from "./acl/class";
 export {
+  unstable_discoverInbox,
+  unstable_fetchInbox,
+} from "./notifications/ldn";
+export {
   Url,
   Iri,
   UrlString,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -114,6 +114,7 @@ export type WithResourceInfo = {
     fetchedFrom: UrlString;
     isLitDataset: boolean;
     contentType?: string;
+    inbox?: string;
     /**
      * The URL reported by the server as possibly containing an ACL file. Note that this file might
      * not necessarily exist, in which case the ACL of the nearest Container with an ACL applies.

--- a/src/litDataset.ts
+++ b/src/litDataset.ts
@@ -305,7 +305,11 @@ function getNamedNodesForLocalNodes(quad: Quad): Quad {
   };
 }
 
-function getNamedNodeFromLocalNode(localNode: LocalNode): NamedNode {
+/**
+ * @internal
+ * @param localNode
+ */
+export function getNamedNodeFromLocalNode(localNode: LocalNode): NamedNode {
   return DataFactory.namedNode("#" + localNode.name);
 }
 

--- a/src/notifications/ldn.test.ts
+++ b/src/notifications/ldn.test.ts
@@ -30,7 +30,7 @@ import {
 } from "./ldn";
 import { DataFactory, dataset } from "../rdfjs";
 import Dataset from "@rdfjs/dataset";
-import { option } from "rdf-namespaces/dist/sched";
+
 jest.mock("../fetcher.ts", () => ({
   fetch: jest.fn().mockImplementation(() =>
     Promise.resolve(

--- a/src/notifications/ldn.test.ts
+++ b/src/notifications/ldn.test.ts
@@ -473,29 +473,30 @@ describe("unstable_sendNotification", () => {
 
   it("should send the notification to the inbox of the given resource if found in its content", async () => {
     const turtle = `
-      @prefix : <#>.
       @prefix ldp: <https://www.w3.org/ns/ldp#>.
 
-      :aResource ldp:inbox :anInbox.
+      </aContainer/aResource> ldp:inbox </anotherContainer/anInbox>.
     `;
     const mockFetch = jest.fn(window.fetch).mockReturnValue(
       Promise.resolve(
         mockResponse(turtle, {
           url: "https://some.pod/",
           headers: {
-            Location: "https://some.pod/anInbox/notification",
+            Location: "https://some.pod/aContainer/anInbox/notification",
           },
         })
       )
     );
     await unstable_sendNotification(
       dataset(),
-      DataFactory.namedNode("https://some.pod#aResource"),
+      DataFactory.namedNode("https://some.pod/aContainer/aResource"),
       {
         fetch: mockFetch,
       }
     );
-    expect(mockFetch.mock.calls[2][0]).toEqual("https://some.pod#anInbox");
+    expect(mockFetch.mock.calls[2][0]).toEqual(
+      "https://some.pod/anotherContainer/anInbox"
+    );
   });
 
   it("should send the provided notification to the inbox of the target resource", async () => {

--- a/src/notifications/ldn.test.ts
+++ b/src/notifications/ldn.test.ts
@@ -249,7 +249,7 @@ describe("unstable_buildNotification", () => {
     expect(getUrlOne(notification, rdf.type)).toEqual(as.Event);
   });
 
-  it("should complete the notification with the optional body if provided", () => {
+  it("should complete the notification with the optional subthings if provided", () => {
     let body = dataset();
     body.add(
       DataFactory.quad(
@@ -267,7 +267,7 @@ describe("unstable_buildNotification", () => {
       DataFactory.namedNode("https://your.pod/webId#you"),
       DataFactory.namedNode(as.Event),
       {
-        body: { "https://some.other/predicate": bodyThing },
+        subthings: { "https://some.other/predicate": bodyThing },
       }
     );
     const notification = getThingOne(
@@ -307,7 +307,7 @@ describe("unstable_buildNotification", () => {
       DataFactory.namedNode("https://your.pod/webId#you"),
       DataFactory.namedNode(as.Event),
       {
-        body: { "https://some.other/predicate": body },
+        subthings: { "https://some.other/predicate": body },
       }
     );
     const notification = getThingOne(
@@ -332,6 +332,47 @@ describe("unstable_buildNotification", () => {
         getThingOne(notificationData, body.localSubject),
         "https://my.pod/some/arbitrary/predicate"
       )
+    ).toEqual("https://my.pod/some/arbitrary/object");
+  });
+
+  it("should use the provided optional body if provided", () => {
+    let body = dataset();
+    body.add(
+      DataFactory.quad(
+        DataFactory.namedNode("https://my.pod/some/notification"),
+        DataFactory.namedNode("https://my.pod/some/arbitrary/predicate"),
+        DataFactory.namedNode("https://my.pod/some/arbitrary/object")
+      )
+    );
+    const bodyThing = getThingOne(body, "https://my.pod/some/notification");
+    const notificationData = unstable_buildNotification(
+      DataFactory.namedNode("https://my.pod/webId#me"),
+      DataFactory.namedNode("https://your.pod/webId#you"),
+      DataFactory.namedNode(as.Event),
+      {
+        body: bodyThing,
+      }
+    );
+    const notification = getThingOne(
+      notificationData,
+      notificationData.notification
+    );
+
+    // The core notification elements should not be changed
+    expect(getUrlOne(notification, as.actor)).toEqual(
+      "https://my.pod/webId#me"
+    );
+    expect(getUrlOne(notification, as.target)).toEqual(
+      "https://your.pod/webId#you"
+    );
+    expect(getUrlOne(notification, rdf.type)).toEqual(as.Event);
+    // The provided IRI should be used
+    expect(notificationData.notification).toEqual(
+      "https://my.pod/some/notification"
+    );
+    // The body should be added
+    expect(
+      getUrlOne(notification, "https://my.pod/some/arbitrary/predicate")
     ).toEqual("https://my.pod/some/arbitrary/object");
   });
 });

--- a/src/notifications/ldn.test.ts
+++ b/src/notifications/ldn.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import {
+  unstable_discoverInbox,
+  unstable_sendNotification,
+  unstable_buildNotification,
+  unstable_fetchInbox,
+  unstable_sendNotificationToInbox,
+} from "./ldn";
+import { DataFactory, dataset } from "../rdfjs";
+import Dataset from "@rdfjs/dataset";
+jest.mock("../fetcher.ts", () => ({
+  fetch: jest.fn().mockImplementation(() =>
+    Promise.resolve(
+      new Response(undefined, {
+        headers: { Location: "https://arbitrary.pod/resource" },
+      })
+    )
+  ),
+}));
+
+describe("unstable_discoverInbox", () => {
+  it("should return the inbox IRI for a given resource", () => {
+    unstable_discoverInbox(
+      DataFactory.namedNode("https://some.pod/resource"),
+      dataset()
+    );
+    // TODO: Unimplemented
+    expect(null).toBeNull();
+  });
+
+  it("should return null if no inbox is available in the dataset", () => {
+    // TODO: Unimplemented
+    expect(null).toBeNull();
+  });
+
+  it("should ignore inboxes for other resources", () => {
+    // TODO: Unimplemented
+    expect(null).toBeNull();
+  });
+});
+
+describe("unstable_fetchInbox", () => {
+  it("should return the inbox IRI for a given resource", async () => {
+    await unstable_fetchInbox(
+      DataFactory.namedNode("https://some.pod/resource")
+    );
+    expect(null).toBeNull();
+  });
+
+  it("should return null if no inbox is available in the dataset", () => {
+    // TODO: Unimplemented
+    expect(null).toBeNull();
+  });
+
+  it("should ignore inboxes for other resources", () => {
+    // TODO: Unimplemented
+    expect(null).toBeNull();
+  });
+});
+
+describe("unstable_buildNotification", () => {
+  it("should create a notification with the provided values", () => {
+    unstable_buildNotification(
+      DataFactory.namedNode("https://my.pod/webId#me"),
+      DataFactory.namedNode("https://your.pod/webId#you"),
+      // TODO: replace with a constant ?
+      DataFactory.namedNode("https://www.w3.org/ns/activitystreams/Event")
+    );
+    // TODO: test for provided values
+    expect(null).toBeNull();
+  });
+
+  it("should complete the notification with the optional body if provided", () => {
+    // TODO: Test for provided body
+    expect(null).toBeNull();
+  });
+});
+
+describe("unstable_sendNotification", () => {
+  it("should use the provided fetcher if applicable", async () => {
+    // TODO: Unimplemented
+    expect(null).toBeNull();
+  });
+
+  it("should default to the fallback fetcher if no other is provided", async () => {
+    // TODO: Unimplemented
+    expect(null).toBeNull();
+  });
+
+  it("should send the provided notification to the inbox of the target resource", async () => {
+    await unstable_sendNotification(
+      dataset(),
+      Dataset.namedNode("https://your.pod/webId#you")
+    );
+    // TODO: Unimplemented
+    expect(null).toBeNull();
+  });
+
+  it("should fail if inbox discovery fails", async () => {
+    // TODO: Unimplemented
+    expect(null).toBeNull();
+  });
+});
+
+describe("unstable_sendNotificationToInbox", () => {
+  it("should use the provided fetcher if applicable", async () => {
+    // TODO: Unimplemented
+    expect(null).toBeNull();
+  });
+
+  it("should default to the fallback fetcher if no other is provided", async () => {
+    // TODO: Unimplemented
+    expect(null).toBeNull();
+  });
+
+  it("should send the provided notification to the target inbox", async () => {
+    await unstable_sendNotificationToInbox(
+      dataset(),
+      Dataset.namedNode("https://your.pod/inbox")
+    );
+    // TODO: Unimplemented
+    expect(null).toBeNull();
+  });
+
+  it("should not perform inbox discovery", async () => {
+    // TODO: Unimplemented
+    expect(null).toBeNull();
+  });
+});

--- a/src/notifications/ldn.ts
+++ b/src/notifications/ldn.ts
@@ -19,18 +19,34 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { LitDataset, Iri, Thing, IriString } from "../interfaces";
+import {
+  LitDataset,
+  Iri,
+  Thing,
+  IriString,
+  WithResourceInfo,
+} from "../interfaces";
 import { dataset, DataFactory } from "../rdfjs";
 import { fetch } from "../fetcher";
 import {
   internal_fetchResourceInfo,
   hasInboxInfo,
   getInboxInfo,
+  internal_toString
 } from "../resource";
-import { fetchLitDataset } from "../litDataset";
+import { 
+  fetchLitDataset, 
+  saveLitDatasetInContainer 
+} from "../litDataset";
 import { getThingOne } from "../thing";
 import { getIriOne } from "../thing/get";
 import { ldp } from "../constants";
+import { triplesToTurtle } from "../formats/turtle";
+
+/** @internal */
+export const internal_defaultFetchOptions = {
+  fetch: fetch,
+};
 
 /**
  * Perform partial inbox discovery (https://www.w3.org/TR/ldn/#discovery) by only checking
@@ -84,23 +100,34 @@ export function unstable_buildNotification(
   return dataset();
 }
 
+/**
+ * Send a notification to a given target inbox, without performing any discovery.
+ *
+ * @param notification The [[LitDataset]] containing the notification data.
+ * @param inbox URL of the target inbox.
+ * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * @returns A Promise resolving to a [[LitDataset]] containing the stored data linked to the new notification Resource, or rejecting if saving it failed.
+ */
 export async function unstable_sendNotificationToInbox(
   notification: LitDataset,
   inbox: Iri | IriString,
-  options?: {
-    fetch: typeof fetch;
-  }
-) {
-  // NOTE: Unimplemented
-  void 0;
+  options: Partial<
+    typeof internal_defaultFetchOptions
+  > = internal_defaultFetchOptions
+): Promise<LitDataset & WithResourceInfo> {
+  return saveLitDatasetInContainer(
+    internal_toString(inbox),
+    notification,
+    options
+  );
 }
 
 export async function unstable_sendNotification(
   notification: LitDataset,
   receiver: Iri | IriString,
-  options?: {
-    fetch: typeof fetch;
-  }
+  options: Partial<
+    typeof internal_defaultFetchOptions
+  > = internal_defaultFetchOptions
 ) {
   // NOTE: Unimplemented
   void 0;

--- a/src/notifications/ldn.ts
+++ b/src/notifications/ldn.ts
@@ -184,6 +184,14 @@ function addThingToNotification(
   return result;
 }
 
+/**
+ * Discovers the inbox of the provided target resource, and then sends the provided notification to that inbox.
+ * Fails if no inbox is discovered.
+ * @param notification The content of thoe notification
+ * @param receiver The target resource (e.g. a WebID)
+ * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * @returns A Promise resolving to a [[LitDataset]] containing the stored data linked to the new notification Resource, or rejecting if saving it failed.
+ */
 export async function unstable_sendNotification(
   notification: LitDataset,
   receiver: Url | UrlString,

--- a/src/notifications/ldn.ts
+++ b/src/notifications/ldn.ts
@@ -25,7 +25,7 @@ import { fetch } from "../fetcher";
 
 /**
  * Perform partial inbox discovery (https://www.w3.org/TR/ldn/#discovery) by only checking
- * resource content. If the inbox is only advsertised in the resource metadata, it won't be
+ * resource content. If the inbox is only advertised in the resource metadata, it won't be
  * discovered.
  *
  * @param resource The IRI of the resource for which we are searching for the inbox

--- a/src/notifications/ldn.ts
+++ b/src/notifications/ldn.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { LitDataset, Iri, Thing, IriString } from "../interfaces";
+import { dataset, DataFactory } from "../rdfjs";
+import { fetch } from "../fetcher";
+
+/**
+ * Perform partial inbox discovery (https://www.w3.org/TR/ldn/#discovery) by only checking
+ * resource content. If the inbox is only advsertised in the resource metadata, it won't be
+ * discovered.
+ *
+ * @param resource The IRI of the resource for which we are searching for the inbox
+ * @param dataset The dataset where the inbox may be found (typically fetched at the resource IRI)
+ */
+export function unstable_discoverInbox(
+  resource: Iri | IriString,
+  dataset: LitDataset
+): Iri {
+  return DataFactory.namedNode("unimplemented");
+}
+
+/**
+ * Perform complete inbox discovery (https://www.w3.org/TR/ldn/#discovery) by checking both
+ * resource metedata (i.e. Link headers) and resource content.
+ *
+ * @param resource The IRI of the resource for which we are searching for the inbox
+ * @param dataset The dataset where the inbox may be found (typically fetched at the resource IRI)
+ */
+export async function unstable_fetchInbox(resource: Iri | IriString) {
+  return DataFactory.namedNode("unimplemented");
+}
+
+export function unstable_buildNotification(
+  sender: Iri | IriString,
+  target: Iri | IriString,
+  type: Iri | IriString,
+  options?: {
+    body: LitDataset;
+  }
+): LitDataset {
+  // NOTE: Unimplemented
+  return dataset();
+}
+
+export async function unstable_sendNotificationToInbox(
+  notification: LitDataset,
+  inbox: Iri | IriString,
+  options?: {
+    fetch: typeof fetch;
+  }
+) {
+  // NOTE: Unimplemented
+  void 0;
+}
+
+export async function unstable_sendNotification(
+  notification: LitDataset,
+  receiver: Iri | IriString,
+  options?: {
+    fetch: typeof fetch;
+  }
+) {
+  // NOTE: Unimplemented
+  void 0;
+}

--- a/src/notifications/ldn.ts
+++ b/src/notifications/ldn.ts
@@ -23,7 +23,6 @@ import {
   LitDataset,
   Url,
   Thing,
-  IriString,
   WithResourceInfo,
   WebId,
   LocalNode,
@@ -35,19 +34,19 @@ import {
   internal_fetchResourceInfo,
   hasInboxInfo,
   getInboxInfo,
-  internal_toString
+  internal_toString,
 } from "../resource";
-import { 
-  fetchLitDataset, 
+import {
+  fetchLitDataset,
   saveLitDatasetInContainer,
-  getNamedNodeFromLocalNode, 
+  getNamedNodeFromLocalNode,
 } from "../litDataset";
-import { 
-  getThingOne, 
-  createThing, 
-  isThingLocal, 
-  setThing, 
-  cloneThing
+import {
+  getThingOne,
+  createThing,
+  isThingLocal,
+  setThing,
+  cloneThing,
 } from "../thing";
 import { getIriOne } from "../thing/get";
 import { ldp, as, rdf } from "../constants";
@@ -64,7 +63,7 @@ import { addUrl } from "../thing/add";
  * discovered.
  *
  * @param resource The URL of the resource for which we are searching for the inbox
- * @param dataset The dataset where the inbox may be found (typically fetched at the resource IRI)
+ * @param dataset The dataset where the inbox may be found (typically fetched at the resource Url)
  */
 export function unstable_discoverInbox(
   resource: Url | UrlString,
@@ -79,10 +78,10 @@ export function unstable_discoverInbox(
  * resource metedata (i.e. Link headers) and resource content.
  *
  * @param resource The URL of the resource for which we are searching for the inbox
- * @param dataset The dataset where the inbox may be found (typically fetched at the resource IRI)
+ * @param dataset The dataset where the inbox may be found (typically fetched at the resource Url)
  */
 export async function unstable_fetchInbox(
-  resource: Iri | IriString,
+  resource: Url | UrlString,
   options?: {
     fetch: typeof fetch;
   }
@@ -100,7 +99,7 @@ export async function unstable_fetchInbox(
 
 /**
  * Creates a dataset describing a notification. The obtained notification has a relative
- * IRI that is resolved when it is sent to an inbox.
+ * Url that is resolved when it is sent to an inbox.
  *
  * @param sender The URL identifying the sender of the resource (typically, a WebID)
  * @param target The URL identifying the receiver of the resource (typically, a WebID)
@@ -154,7 +153,7 @@ export function unstable_buildNotification(
  */
 export async function unstable_sendNotificationToInbox(
   notification: LitDataset,
-  inbox: Iri | IriString,
+  inbox: Url | UrlString,
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
@@ -172,7 +171,7 @@ function addThingToNotification(
   thing: Thing
 ): Thing {
   let result = cloneThing(notification);
-  // The notification subpart is linked to the notification IRI using the given predicate
+  // The notification subpart is linked to the notification Url using the given predicate
   if (isThingLocal(thing)) {
     result = addUrl(
       result,
@@ -187,7 +186,7 @@ function addThingToNotification(
 
 export async function unstable_sendNotification(
   notification: LitDataset,
-  receiver: Iri | IriString,
+  receiver: Url | UrlString,
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions

--- a/src/notifications/ldn.ts
+++ b/src/notifications/ldn.ts
@@ -82,9 +82,9 @@ export function unstable_discoverInbox(
  */
 export async function unstable_fetchInbox(
   resource: Url | UrlString,
-  options?: {
-    fetch: typeof fetch;
-  }
+  options: Partial<
+    typeof internal_defaultFetchOptions
+  > = internal_defaultFetchOptions
 ): Promise<string | null> {
   const resourceIri = typeof resource === "string" ? resource : resource.value;
   // First, try to get a Link header to the inbox
@@ -191,6 +191,11 @@ export async function unstable_sendNotification(
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
 ) {
-  // NOTE: Unimplemented
-  void 0;
+  const inbox = await unstable_fetchInbox(receiver, options);
+  if (inbox === null) {
+    throw new Error(
+      `No inbox discovered for resource [${internal_toString(receiver)}]`
+    );
+  }
+  return unstable_sendNotificationToInbox(notification, inbox, options);
 }

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -28,10 +28,12 @@ import {
   unstable_AclDataset,
   unstable_hasAccessibleAcl,
   unstable_Access,
+  Url,
 } from "./interfaces";
 import { saveLitDatasetAt } from "./litDataset";
 import { fetch } from "./fetcher";
 import { internal_fetchResourceAcl, internal_fetchFallbackAcl } from "./acl";
+import { ldp } from "./constants";
 
 /** @internal */
 export const internal_defaultFetchOptions = {
@@ -150,10 +152,19 @@ export function internal_parseResourceInfo(
   const linkHeader = response.headers.get("Link");
   if (linkHeader) {
     const parsedLinks = LinkHeader.parse(linkHeader);
+    // Set ACL link
     const aclLinks = parsedLinks.get("rel", "acl");
     if (aclLinks.length === 1) {
       resourceInfo.unstable_aclUrl = new URL(
         aclLinks[0].uri,
+        resourceInfo.fetchedFrom
+      ).href;
+    }
+    // Set inbox link
+    const inboxLinks = parsedLinks.get("rel", ldp.inbox);
+    if (inboxLinks.length === 1) {
+      resourceInfo.inbox = new URL(
+        inboxLinks[0].uri,
         resourceInfo.fetchedFrom
       ).href;
     }
@@ -197,6 +208,14 @@ export function getContentType(resource: WithResourceInfo): string | null {
  */
 export function getFetchedFrom(resource: WithResourceInfo): string {
   return resource.resourceInfo.fetchedFrom;
+}
+
+export function hasInboxInfo(resource: WithResourceInfo): boolean {
+  return typeof resource.resourceInfo.inbox === "string";
+}
+
+export function getInboxInfo(resource: WithResourceInfo): string | null {
+  return resource.resourceInfo.inbox ?? null;
 }
 
 /**

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -28,7 +28,8 @@ import {
   unstable_AclDataset,
   unstable_hasAccessibleAcl,
   unstable_Access,
-  Url,
+  IriString,
+  Iri,
 } from "./interfaces";
 import { saveLitDatasetAt } from "./litDataset";
 import { fetch } from "./fetcher";
@@ -336,4 +337,8 @@ function parseWacAllowHeader(wacAllowHeader: string) {
     user: parsePermissionStatement(getStatementFor(wacAllowHeader, "user")),
     public: parsePermissionStatement(getStatementFor(wacAllowHeader, "public")),
   };
+}
+
+export function internal_toString(iri: Iri | IriString): string {
+  return typeof iri === "string" ? iri : iri.value;
 }


### PR DESCRIPTION
This adds the capability to send an LDN notification to a target resource. 

NOTE: I'm experimenting an alternative flow to ease review: each atomic feature (e.g. inbox discovery or notification building) are going to be developped in their individual branches (e.g. `feat/notification/discovery`) and gradually merged into this branch (`feat/notification/main`). Only when all the features are developped, this PR will be switched off the draft state for a final (quick) review, given that each individual feature has been reviewed previously. 

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
