### PR TITLE
Add notificaton sending feature

### DIFF
--- a/src/notifications/ldn.ts
+++ b/src/notifications/ldn.ts
@@ -19,18 +19,34 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { LitDataset, Iri, Thing, IriString } from "../interfaces";
+import {
+  LitDataset,
+  Iri,
+  Thing,
+  IriString,
+  WithResourceInfo,
+} from "../interfaces";
 import { dataset, DataFactory } from "../rdfjs";
 import { fetch } from "../fetcher";
 import {
   internal_fetchResourceInfo,
   hasInboxInfo,
   getInboxInfo,
+  internal_toString
 } from "../resource";
-import { fetchLitDataset } from "../litDataset";
+import { 
+  fetchLitDataset, 
+  saveLitDatasetInContainer 
+} from "../litDataset";
 import { getThingOne } from "../thing";
 import { getIriOne } from "../thing/get";
 import { ldp } from "../constants";
+import { triplesToTurtle } from "../formats/turtle";
+
+/** @internal */
+export const internal_defaultFetchOptions = {
+  fetch: fetch,
+};
 
 /**
  * Perform partial inbox discovery (https://www.w3.org/TR/ldn/#discovery) by only checking
@@ -84,23 +100,34 @@ export function unstable_buildNotification(
   return dataset();
 }
 
+/**
+ * Send a notification to a given target inbox, without performing any discovery.
+ *
+ * @param notification The [[LitDataset]] containing the notification data.
+ * @param inbox URL of the target inbox.
+ * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * @returns A Promise resolving to a [[LitDataset]] containing the stored data linked to the new notification Resource, or rejecting if saving it failed.
+ */
 export async function unstable_sendNotificationToInbox(
   notification: LitDataset,
   inbox: Iri | IriString,
-  options?: {
-    fetch: typeof fetch;
-  }
-) {
-  // NOTE: Unimplemented
-  void 0;
+  options: Partial<
+    typeof internal_defaultFetchOptions
+  > = internal_defaultFetchOptions
+): Promise<LitDataset & WithResourceInfo> {
+  return saveLitDatasetInContainer(
+    internal_toString(inbox),
+    notification,
+    options
+  );
 }
 
 export async function unstable_sendNotification(
   notification: LitDataset,
   receiver: Iri | IriString,
-  options?: {
-    fetch: typeof fetch;
-  }
+  options: Partial<
+    typeof internal_defaultFetchOptions
+  > = internal_defaultFetchOptions
 ) {
   // NOTE: Unimplemented
   void 0;

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -28,7 +28,8 @@ import {
   unstable_AclDataset,
   unstable_hasAccessibleAcl,
   unstable_Access,
-  Url,
+  IriString,
+  Iri,
 } from "./interfaces";
 import { saveLitDatasetAt } from "./litDataset";
 import { fetch } from "./fetcher";
@@ -336,4 +337,8 @@ function parseWacAllowHeader(wacAllowHeader: string) {
     user: parsePermissionStatement(getStatementFor(wacAllowHeader, "user")),
     public: parsePermissionStatement(getStatementFor(wacAllowHeader, "public")),
   };
+}
+
+export function internal_toString(iri: Iri | IriString): string {
+  return typeof iri === "string" ? iri : iri.value;
 }


### PR DESCRIPTION
This adds the possibility to send a notification to an inbox that already has been discovered. Note that the convenience function both performing the discovery and sending the notification will be done in a different commit, dependent on this one and #241.

# Checklist

- [X] All acceptance criteria are met.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
