### PR TITLE
Add function helping to create notifications

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,3 +48,10 @@ export const foaf = {
 export const ldp = {
   inbox: "https://www.w3.org/ns/ldp#inbox",
 } as const;
+
+/** @internal */
+export const as = {
+  actor: "https://www.w3.org/ns/activitystreams#actor",
+  target: "https://www.w3.org/ns/activitystreams#target",
+  Event: "https://www.w3.org/ns/activitystreams#Event",
+} as const;

--- a/src/datatypes.ts
+++ b/src/datatypes.ts
@@ -237,7 +237,7 @@ export function asNamedNode(iri: Iri | IriString): NamedNode {
     return iri;
   }
   // If the runtime environment supports URL, instantiate one.
-  // If thte given IRI is not a valid URL, it will throw an error.
+  // If the given IRI is not a valid URL, it will throw an error.
   // See: https://developer.mozilla.org/en-US/docs/Web/API/URL
   /* istanbul ignore else [URL is available in our testing environment, so we cannot test the alternative] */
   if (typeof URL !== "undefined") {

--- a/src/litDataset.ts
+++ b/src/litDataset.ts
@@ -305,7 +305,11 @@ function getNamedNodesForLocalNodes(quad: Quad): Quad {
   };
 }
 
-function getNamedNodeFromLocalNode(localNode: LocalNode): NamedNode {
+/**
+ * @internal
+ * @param localNode
+ */
+export function getNamedNodeFromLocalNode(localNode: LocalNode): NamedNode {
   return DataFactory.namedNode("#" + localNode.name);
 }
 

--- a/src/notifications/ldn.test.ts
+++ b/src/notifications/ldn.test.ts
@@ -249,7 +249,7 @@ describe("unstable_buildNotification", () => {
     expect(getUrlOne(notification, rdf.type)).toEqual(as.Event);
   });
 
-  it("should complete the notification with the optional body if provided", () => {
+  it("should complete the notification with the optional subthings if provided", () => {
     let body = dataset();
     body.add(
       DataFactory.quad(
@@ -267,7 +267,7 @@ describe("unstable_buildNotification", () => {
       DataFactory.namedNode("https://your.pod/webId#you"),
       DataFactory.namedNode(as.Event),
       {
-        body: { "https://some.other/predicate": bodyThing },
+        subthings: { "https://some.other/predicate": bodyThing },
       }
     );
     const notification = getThingOne(
@@ -307,7 +307,7 @@ describe("unstable_buildNotification", () => {
       DataFactory.namedNode("https://your.pod/webId#you"),
       DataFactory.namedNode(as.Event),
       {
-        body: { "https://some.other/predicate": body },
+        subthings: { "https://some.other/predicate": body },
       }
     );
     const notification = getThingOne(
@@ -332,6 +332,47 @@ describe("unstable_buildNotification", () => {
         getThingOne(notificationData, body.localSubject),
         "https://my.pod/some/arbitrary/predicate"
       )
+    ).toEqual("https://my.pod/some/arbitrary/object");
+  });
+
+  it("should use the provided optional body if provided", () => {
+    let body = dataset();
+    body.add(
+      DataFactory.quad(
+        DataFactory.namedNode("https://my.pod/some/notification"),
+        DataFactory.namedNode("https://my.pod/some/arbitrary/predicate"),
+        DataFactory.namedNode("https://my.pod/some/arbitrary/object")
+      )
+    );
+    const bodyThing = getThingOne(body, "https://my.pod/some/notification");
+    const notificationData = unstable_buildNotification(
+      DataFactory.namedNode("https://my.pod/webId#me"),
+      DataFactory.namedNode("https://your.pod/webId#you"),
+      DataFactory.namedNode(as.Event),
+      {
+        body: bodyThing,
+      }
+    );
+    const notification = getThingOne(
+      notificationData,
+      notificationData.notification
+    );
+
+    // The core notification elements should not be changed
+    expect(getUrlOne(notification, as.actor)).toEqual(
+      "https://my.pod/webId#me"
+    );
+    expect(getUrlOne(notification, as.target)).toEqual(
+      "https://your.pod/webId#you"
+    );
+    expect(getUrlOne(notification, rdf.type)).toEqual(as.Event);
+    // The provided IRI should be used
+    expect(notificationData.notification).toEqual(
+      "https://my.pod/some/notification"
+    );
+    // The body should be added
+    expect(
+      getUrlOne(notification, "https://my.pod/some/arbitrary/predicate")
     ).toEqual("https://my.pod/some/arbitrary/object");
   });
 });

--- a/src/notifications/ldn.ts
+++ b/src/notifications/ldn.ts
@@ -23,7 +23,6 @@ import {
   LitDataset,
   Url,
   Thing,
-  IriString,
   WithResourceInfo,
   WebId,
   LocalNode,
@@ -35,19 +34,19 @@ import {
   internal_fetchResourceInfo,
   hasInboxInfo,
   getInboxInfo,
-  internal_toString
+  internal_toString,
 } from "../resource";
-import { 
-  fetchLitDataset, 
+import {
+  fetchLitDataset,
   saveLitDatasetInContainer,
-  getNamedNodeFromLocalNode, 
+  getNamedNodeFromLocalNode,
 } from "../litDataset";
-import { 
-  getThingOne, 
-  createThing, 
-  isThingLocal, 
-  setThing, 
-  cloneThing
+import {
+  getThingOne,
+  createThing,
+  isThingLocal,
+  setThing,
+  cloneThing,
 } from "../thing";
 import { getIriOne } from "../thing/get";
 import { ldp, as, rdf } from "../constants";
@@ -64,7 +63,7 @@ import { addUrl } from "../thing/add";
  * discovered.
  *
  * @param resource The URL of the resource for which we are searching for the inbox
- * @param dataset The dataset where the inbox may be found (typically fetched at the resource IRI)
+ * @param dataset The dataset where the inbox may be found (typically fetched at the resource Url)
  */
 export function unstable_discoverInbox(
   resource: Url | UrlString,
@@ -79,10 +78,10 @@ export function unstable_discoverInbox(
  * resource metedata (i.e. Link headers) and resource content.
  *
  * @param resource The URL of the resource for which we are searching for the inbox
- * @param dataset The dataset where the inbox may be found (typically fetched at the resource IRI)
+ * @param dataset The dataset where the inbox may be found (typically fetched at the resource Url)
  */
 export async function unstable_fetchInbox(
-  resource: Iri | IriString,
+  resource: Url | UrlString,
   options?: {
     fetch: typeof fetch;
   }
@@ -100,7 +99,7 @@ export async function unstable_fetchInbox(
 
 /**
  * Creates a dataset describing a notification. The obtained notification has a relative
- * IRI that is resolved when it is sent to an inbox.
+ * Url that is resolved when it is sent to an inbox.
  *
  * @param sender The URL identifying the sender of the resource (typically, a WebID)
  * @param target The URL identifying the receiver of the resource (typically, a WebID)
@@ -154,7 +153,7 @@ export function unstable_buildNotification(
  */
 export async function unstable_sendNotificationToInbox(
   notification: LitDataset,
-  inbox: Iri | IriString,
+  inbox: Url | UrlString,
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
@@ -172,7 +171,7 @@ function addThingToNotification(
   thing: Thing
 ): Thing {
   let result = cloneThing(notification);
-  // The notification subpart is linked to the notification IRI using the given predicate
+  // The notification subpart is linked to the notification Url using the given predicate
   if (isThingLocal(thing)) {
     result = addUrl(
       result,
@@ -187,7 +186,7 @@ function addThingToNotification(
 
 export async function unstable_sendNotification(
   notification: LitDataset,
-  receiver: Iri | IriString,
+  receiver: Url | UrlString,
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions


### PR DESCRIPTION
This adds a function that helps creating a notification. Only elements that are certain to be relevant (sender, target and notification type) are mandatory. Any additional notification information should be specified as a Thing, along with the predicate connecting it to the notification.

# Checklist

- [X] All acceptance criteria are met.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
