### PR TITLE
Feat/notification/discover and send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@ First release! What's possible with this first release:
 - Manipulate data in datasets.
 - Inspect a user's, group's and public permissions w.r.t. a given Resource or child Resources of a Container. (Experimental.)
 - Retrieve, delete and/or write any file (including non-RDF) from/to a Pod. (Experimental.)
+- Create and send an asynchronous notification

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -179,7 +179,9 @@ describe("End-to-end tests", () => {
       });
       await unstable_saveAclFor(datasetWithAcl, cleanedAcl);
     }
-  });
+    // Fetching both Resource and Fallback ACLs takes quite a while on a bad network connection,
+    // so double Jest's default timeout of 5 seconds:
+  }, 10000);
 
   it("can copy default rules from the fallback ACL as Resource rules to a new ACL", async () => {
     const dataset = await unstable_fetchLitDatasetWithAcl(
@@ -196,7 +198,9 @@ describe("End-to-end tests", () => {
         unstable_getPublicResourceAccess(newResourceAcl)
       );
     }
-  });
+    // Fetching both Resource and Fallback ACLs takes quite a while on a bad network connection,
+    // so double Jest's default timeout of 5 seconds:
+  }, 10000);
 
   it("can fetch a non-RDF file and its metadata", async () => {
     const jsonFile = await unstable_fetchFile(

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -130,6 +130,9 @@ import {
   removeStringInLocale,
   unstable_discoverInbox,
   unstable_fetchInbox,
+  unstable_buildNotification,
+  unstable_sendNotification,
+  unstable_sendNotificationToInbox,
 } from "./index";
 
 // These tests aren't too useful in preventing bugs, but they work around this issue:
@@ -234,6 +237,9 @@ it("exports the public API from the entry file", () => {
   expect(unstable_getGroupDefaultAccessAll).toBeDefined();
   expect(unstable_discoverInbox).toBeDefined(),
     expect(unstable_fetchInbox).toBeDefined();
+  expect(unstable_buildNotification).toBeDefined();
+  expect(unstable_sendNotification).toBeDefined();
+  expect(unstable_sendNotificationToInbox).toBeDefined();
 });
 
 it("still exports deprecated methods", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,6 +167,9 @@ export {
 export {
   unstable_discoverInbox,
   unstable_fetchInbox,
+  unstable_buildNotification,
+  unstable_sendNotification,
+  unstable_sendNotificationToInbox,
 } from "./notifications/ldn";
 export {
   Url,

--- a/src/notifications/ldn.test.ts
+++ b/src/notifications/ldn.test.ts
@@ -473,29 +473,30 @@ describe("unstable_sendNotification", () => {
 
   it("should send the notification to the inbox of the given resource if found in its content", async () => {
     const turtle = `
-      @prefix : <#>.
       @prefix ldp: <https://www.w3.org/ns/ldp#>.
 
-      :aResource ldp:inbox :anInbox.
+      </aContainer/aResource> ldp:inbox </anotherContainer/anInbox>.
     `;
     const mockFetch = jest.fn(window.fetch).mockReturnValue(
       Promise.resolve(
         mockResponse(turtle, {
           url: "https://some.pod/",
           headers: {
-            Location: "https://some.pod/anInbox/notification",
+            Location: "https://some.pod/aContainer/anInbox/notification",
           },
         })
       )
     );
     await unstable_sendNotification(
       dataset(),
-      DataFactory.namedNode("https://some.pod#aResource"),
+      DataFactory.namedNode("https://some.pod/aContainer/aResource"),
       {
         fetch: mockFetch,
       }
     );
-    expect(mockFetch.mock.calls[2][0]).toEqual("https://some.pod#anInbox");
+    expect(mockFetch.mock.calls[2][0]).toEqual(
+      "https://some.pod/anotherContainer/anInbox"
+    );
   });
 
   it("should send the provided notification to the inbox of the target resource", async () => {

--- a/src/notifications/ldn.ts
+++ b/src/notifications/ldn.ts
@@ -184,6 +184,14 @@ function addThingToNotification(
   return result;
 }
 
+/**
+ * Discovers the inbox of the provided target resource, and then sends the provided notification to that inbox.
+ * Fails if no inbox is discovered.
+ * @param notification The content of thoe notification
+ * @param receiver The target resource (e.g. a WebID)
+ * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * @returns A Promise resolving to a [[LitDataset]] containing the stored data linked to the new notification Resource, or rejecting if saving it failed.
+ */
 export async function unstable_sendNotification(
   notification: LitDataset,
   receiver: Url | UrlString,

--- a/src/notifications/ldn.ts
+++ b/src/notifications/ldn.ts
@@ -82,9 +82,9 @@ export function unstable_discoverInbox(
  */
 export async function unstable_fetchInbox(
   resource: Url | UrlString,
-  options?: {
-    fetch: typeof fetch;
-  }
+  options: Partial<
+    typeof internal_defaultFetchOptions
+  > = internal_defaultFetchOptions
 ): Promise<string | null> {
   const resourceIri = typeof resource === "string" ? resource : resource.value;
   // First, try to get a Link header to the inbox
@@ -191,6 +191,11 @@ export async function unstable_sendNotification(
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
 ) {
-  // NOTE: Unimplemented
-  void 0;
+  const inbox = await unstable_fetchInbox(receiver, options);
+  if (inbox === null) {
+    throw new Error(
+      `No inbox discovered for resource [${internal_toString(receiver)}]`
+    );
+  }
+  return unstable_sendNotificationToInbox(notification, inbox, options);
 }


### PR DESCRIPTION
This adds a convenience method that enables, in one API call, to perform both inbox discovery and to send a notification. This complete the feature set, and once merged #239 may be merged as well.

# Checklist

- [X] All acceptance criteria are met.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
