### PR TITLE
Add end-to-end test for LDN Notifications

### DIFF
--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -227,7 +227,6 @@ describe("End-to-end tests", () => {
     if (inboxUrl) {
       const notification = unstable_buildNotification(
         "https://arbitrary.pod/sender#webId",
-        "https://lit-e2e-test.inrupt.net/public/inbox-test/inbox-referrer.ttl",
         as.Read
       );
       const sentNotification = await unstable_sendNotificationToInbox(


### PR DESCRIPTION
This adds an end-to-end test for sending an LDN notification, to verify that I understand how the API works. (Note that if #259 is merged, this PR should set `master` as the target branch.)