### PR TITLE
Only support notifications of a single Thing

### DIFF
--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -48,9 +48,8 @@ import {
   unstable_fetchFile,
   unstable_deleteFile,
   getFetchedFrom,
-  unstable_discoverInbox,
   unstable_buildNotification,
-  unstable_sendNotificationToInbox,
+  unstable_sendNotification,
 } from "./index";
 
 describe("End-to-end tests", () => {
@@ -214,31 +213,23 @@ describe("End-to-end tests", () => {
 
   it("can find and send a notification to an LDN Inbox", async () => {
     expect.assertions(1);
-    const datasetReferringToInbox = await fetchLitDataset(
-      "https://lit-e2e-test.inrupt.net/public/inbox-test/inbox-referrer.ttl"
-    );
-    const inboxUrl = unstable_discoverInbox(
-      "https://lit-e2e-test.inrupt.net/public/inbox-test/inbox-referrer.ttl#referrer-thing",
-      datasetReferringToInbox
-    );
     const as = {
       Read: "https://www.w3.org/ns/activitystreams#Read",
     };
-    if (inboxUrl) {
-      const notification = unstable_buildNotification(
-        "https://arbitrary.pod/sender#webId",
-        as.Read
-      );
-      const sentNotification = await unstable_sendNotificationToInbox(
-        notification,
-        inboxUrl
-      );
-      expect(getFetchedFrom(sentNotification)).toMatch(
-        "https://lit-e2e-test.inrupt.net/public/inbox-test/inbox/"
-      );
+    const notification = unstable_buildNotification(
+      "https://arbitrary.pod/sender#webId",
+      as.Read
+    );
+    // Alternatively, accept a LitDataset instead of the UrlString:
+    const sentNotificationDataset = await unstable_sendNotification(
+      notification,
+      "https://lit-e2e-test.inrupt.net/public/inbox-test/inbox-referrer.ttl#referrer-thing"
+    );
+    expect(getFetchedFrom(sentNotificationDataset)).toMatch(
+      "https://lit-e2e-test.inrupt.net/public/inbox-test/inbox/"
+    );
 
-      // Clean up:
-      await unstable_deleteFile(getFetchedFrom(sentNotification));
-    }
+    // Clean up:
+    await unstable_deleteFile(getFetchedFrom(sentNotificationDataset));
   });
 });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -177,6 +177,11 @@ export type unstable_WithFallbackAcl<
   };
 };
 
+/** @internal */
+export function internal_toIriString(iri: Iri | IriString): IriString {
+  return typeof iri === "string" ? iri : iri.value;
+}
+
 /**
  * Verify whether a given LitDataset includes metadata about where it was retrieved from.
  *

--- a/src/litDataset.ts
+++ b/src/litDataset.ts
@@ -32,6 +32,8 @@ import {
   hasResourceInfo,
   LocalNode,
   unstable_WithAcl,
+  Url,
+  internal_toIriString,
 } from "./interfaces";
 import {
   internal_parseResourceInfo,
@@ -57,11 +59,12 @@ export function createLitDataset(): LitDataset {
  * @returns Promise resolving to a [[LitDataset]] containing the data at the given Resource, or rejecting if fetching it failed.
  */
 export async function fetchLitDataset(
-  url: UrlString,
+  url: UrlString | Url,
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
 ): Promise<LitDataset & WithResourceInfo> {
+  url = internal_toIriString(url);
   const config = {
     ...internal_defaultFetchOptions,
     ...options,
@@ -106,7 +109,7 @@ export async function fetchLitDataset(
  * @returns A LitDataset and the ACLs that apply to it, if available to the authenticated user.
  */
 export async function unstable_fetchLitDatasetWithAcl(
-  url: UrlString,
+  url: UrlString | Url,
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
@@ -125,12 +128,13 @@ export async function unstable_fetchLitDatasetWithAcl(
  * @returns A Promise resolving to a [[LitDataset]] containing the stored data, or rejecting if saving it failed.
  */
 export async function saveLitDatasetAt(
-  url: UrlString,
+  url: UrlString | Url,
   litDataset: LitDataset,
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
 ): Promise<LitDataset & WithResourceInfo & WithChangeLog> {
+  url = internal_toIriString(url);
   const config = {
     ...internal_defaultFetchOptions,
     ...options,
@@ -232,7 +236,7 @@ type SaveInContainerOptions = Partial<
  * @returns A Promise resolving to a [[LitDataset]] containing the stored data linked to the new Resource, or rejecting if saving it failed.
  */
 export async function saveLitDatasetInContainer(
-  containerUrl: UrlString,
+  containerUrl: UrlString | Url,
   litDataset: LitDataset,
   options: SaveInContainerOptions = internal_defaultFetchOptions
 ): Promise<LitDataset & WithResourceInfo> {
@@ -240,6 +244,7 @@ export async function saveLitDatasetInContainer(
     ...internal_defaultFetchOptions,
     ...options,
   };
+  containerUrl = internal_toIriString(containerUrl);
 
   const rawTurtle = await triplesToTurtle(
     Array.from(litDataset).map(getNamedNodesForLocalNodes)

--- a/src/notifications/ldn.ts
+++ b/src/notifications/ldn.ts
@@ -27,6 +27,7 @@ import {
   WebId,
   UrlString,
   internal_toIriString,
+  ThingPersisted,
 } from "../interfaces";
 import { fetch } from "../fetcher";
 import {
@@ -46,6 +47,7 @@ import {
   isThingLocal,
   setThing,
   getThingAll,
+  toNode,
 } from "../thing";
 import { getIriOne, getIriAll } from "../thing/get";
 import { ldp, as, rdf } from "../constants";
@@ -165,23 +167,19 @@ export async function unstable_sendNotificationToInbox(
  */
 export async function unstable_sendNotification(
   notification: Thing,
-  receiver: Url | UrlString,
+  receiver: Url | UrlString | ThingPersisted,
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
 ) {
-  const inbox = await unstable_fetchInbox(receiver, options);
+  // TODO: Change `fetchInbox` to take a `ThingPersisted` and just read the inbox from it directly:
+  const receiverIri = internal_toIriString(toNode(receiver));
+  const inbox = await unstable_fetchInbox(receiverIri, options);
   if (inbox === null) {
-    throw new Error(
-      `No inbox discovered for Resource [${internal_toIriString(receiver)}]`
-    );
+    throw new Error(`No inbox discovered for Resource [${receiverIri}]`);
   }
 
-  const notificationWithTarget = setIri(
-    notification,
-    as.target,
-    internal_toIriString(receiver)
-  );
+  const notificationWithTarget = setIri(notification, as.target, receiver);
 
   let litDataset = createLitDataset();
   litDataset = setThing(litDataset, notificationWithTarget);

--- a/src/notifications/ldn.ts
+++ b/src/notifications/ldn.ts
@@ -96,7 +96,6 @@ export async function unstable_fetchInbox(
  * Url that is resolved when it is sent to an inbox.
  *
  * @param sender The URL identifying the sender of the resource (typically, a WebID)
- * @param target The URL identifying the resource the notification is about
  * @param type The type of notification, typically a type from https://www.w3.org/TR/activitystreams-vocabulary/#activity-types
  * @param options Additional data for the notification. If `body` is set, the provided Thing is used as an initial value for the notification. This makes it easier to set custom properties on a notification. If `subthings` is set, the provided [[Thing]]s are associated to the notification using the provided URLs.
  */

--- a/src/notifications/ldn.ts
+++ b/src/notifications/ldn.ts
@@ -25,19 +25,15 @@ import {
   Thing,
   WithResourceInfo,
   WebId,
-  LocalNode,
   UrlString,
-  IriString,
-  hasResourceInfo,
+  internal_toIriString,
 } from "../interfaces";
 import { fetch } from "../fetcher";
 import {
   internal_fetchResourceInfo,
   hasInboxUrl,
   getInboxUrl,
-  internal_toString,
   isLitDataset,
-  getFetchedFrom,
 } from "../resource";
 import {
   fetchLitDataset,
@@ -74,7 +70,7 @@ export function unstable_discoverInbox(
   dataset: LitDataset,
   receiverUrl: Url | UrlString
 ): UrlString | null {
-  const thingUrl = internal_toString(receiverUrl);
+  const thingUrl = internal_toIriString(receiverUrl);
   const resourceThing = getThingOne(dataset, thingUrl);
   return getIriOne(resourceThing, ldp.inbox);
 }
@@ -92,7 +88,7 @@ export async function unstable_fetchInbox(
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
 ): Promise<UrlString | null> {
-  const resourceIriString = internal_toString(resourceUrl);
+  const resourceIriString = internal_toIriString(resourceUrl);
   // First, try to get a Link header to the inbox:
   const resourceInfo = await internal_fetchResourceInfo(
     resourceIriString,
@@ -152,7 +148,7 @@ export async function unstable_sendNotificationToInbox(
   litDataset = setThing(litDataset, notification);
 
   return saveLitDatasetInContainer(
-    internal_toString(inbox),
+    internal_toIriString(inbox),
     notification,
     options
   );
@@ -177,14 +173,14 @@ export async function unstable_sendNotification(
   const inbox = await unstable_fetchInbox(receiver, options);
   if (inbox === null) {
     throw new Error(
-      `No inbox discovered for Resource [${internal_toString(receiver)}]`
+      `No inbox discovered for Resource [${internal_toIriString(receiver)}]`
     );
   }
 
   const notificationWithTarget = setIri(
     notification,
     as.target,
-    internal_toString(receiver)
+    internal_toIriString(receiver)
   );
 
   let litDataset = createLitDataset();

--- a/src/notifications/ldn.ts
+++ b/src/notifications/ldn.ts
@@ -27,6 +27,8 @@ import {
   WebId,
   LocalNode,
   UrlString,
+  IriString,
+  hasResourceInfo,
 } from "../interfaces";
 import { fetch } from "../fetcher";
 import {
@@ -34,14 +36,22 @@ import {
   hasInboxUrl,
   getInboxUrl,
   internal_toString,
+  isLitDataset,
+  getFetchedFrom,
 } from "../resource";
 import {
   fetchLitDataset,
   saveLitDatasetInContainer,
   createLitDataset,
 } from "../litDataset";
-import { getThingOne, createThing, isThingLocal, setThing } from "../thing";
-import { getIriOne } from "../thing/get";
+import {
+  getThingOne,
+  createThing,
+  isThingLocal,
+  setThing,
+  getThingAll,
+} from "../thing";
+import { getIriOne, getIriAll } from "../thing/get";
 import { ldp, as, rdf } from "../constants";
 
 /** @internal */
@@ -57,98 +67,90 @@ import { setIri } from "../thing/set";
  * discovered.
  *
  * @param resource The URL of the resource for which we are searching for the inbox
+ * @param receiverUrl If the Inbox is specific to a Thing, the URL identifying that Thing.
  * @param dataset The dataset where the inbox may be found (typically fetched at the resource Url)
  */
 export function unstable_discoverInbox(
-  resource: Url | UrlString,
-  dataset: LitDataset
+  dataset: LitDataset,
+  receiverUrl: Url | UrlString
 ): UrlString | null {
-  const inbox = getIriOne(getThingOne(dataset, resource), ldp.inbox);
-  return inbox;
+  const thingUrl = internal_toString(receiverUrl);
+  const resourceThing = getThingOne(dataset, thingUrl);
+  return getIriOne(resourceThing, ldp.inbox);
 }
 
 /**
  * Perform complete inbox discovery (https://www.w3.org/TR/ldn/#discovery) by checking both
  * resource metadata (i.e. Link headers) and resource content.
  *
- * @param resource The URL of the resource for which we are searching for the inbox
+ * @param resourceUrl The URL of the resource for which we are searching for the inbox
  * @param dataset The dataset where the inbox may be found (typically fetched at the resource Url)
  */
 export async function unstable_fetchInbox(
-  resource: Url | UrlString,
+  resourceUrl: Url | UrlString,
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
 ): Promise<UrlString | null> {
-  const resourceIri = typeof resource === "string" ? resource : resource.value;
-  // First, try to get a Link header to the inbox
-  const resourceInfo = await internal_fetchResourceInfo(resourceIri, options);
+  const resourceIriString = internal_toString(resourceUrl);
+  // First, try to get a Link header to the inbox:
+  const resourceInfo = await internal_fetchResourceInfo(
+    resourceIriString,
+    options
+  );
   if (hasInboxUrl({ resourceInfo: resourceInfo })) {
     return getInboxUrl({ resourceInfo: resourceInfo });
   }
-  // If no Link header is defined, look up the resource content
-  const resourceContent = await fetchLitDataset(resourceIri, options);
-  return unstable_discoverInbox(resource, resourceContent);
+
+  // If the Resource does not contain Linked Data, that was our only shot at finding an Inbox:
+  if (!isLitDataset({ resourceInfo: resourceInfo })) {
+    return null;
+  }
+
+  // If it *is* Linked Data, it might contain a reference to the Inbox in its body:
+  const resourceContent = await fetchLitDataset(resourceIriString, options);
+  return unstable_discoverInbox(resourceContent, resourceIriString);
 }
 
 /**
- * Creates a dataset describing a notification. The obtained notification has a relative
- * Url that is resolved when it is sent to an inbox.
+ * Initialises a Notification with recommended data set.
  *
- * @param sender The URL identifying the sender of the resource (typically, a WebID)
- * @param type The type of notification, typically a type from https://www.w3.org/TR/activitystreams-vocabulary/#activity-types
- * @param options Additional data for the notification. If `body` is set, the provided Thing is used as an initial value for the notification. This makes it easier to set custom properties on a notification. If `subthings` is set, the provided [[Thing]]s are associated to the notification using the provided URLs.
+ * The returned notification is a regular [[Thing]], and thus can be extended with any additional
+ * data relevant to the notification.
+ *
+ * @param sender The URL identifying the sender of the resource (typically, a WebID).
+ * @param type The type of notification, typically a type from https://www.w3.org/TR/activitystreams-vocabulary/#activity-types.
  */
 export function unstable_buildNotification(
   sender: Url | WebId,
-  type: Url | UrlString,
-  options?: Partial<{
-    subthings: Record<UrlString, Thing>;
-    body: Thing;
-  }>
-): LitDataset & { notification: UrlString | LocalNode } {
-  let notificationData = createLitDataset();
-  let notification: Thing;
-  if (options && options.body) {
-    notification = options.body;
-    notificationData = setThing(notificationData, notification);
-  } else {
-    notification = createThing();
-  }
-  // Set the mandatory notification properties
+  type: Url | UrlString
+): Thing {
+  let notification = createThing();
   notification = addIri(notification, as.actor, sender);
   notification = addIri(notification, rdf.type, type);
-  // Set the optional additional notification information
-  if (options !== undefined && options.subthings !== undefined) {
-    Object.entries(options.subthings).forEach(([predicate, value]) => {
-      // All the quads of the notification subpart are added to the notification data
-      notificationData = setThing(notification, value);
-      notification = addIri(notification, predicate, value);
-    });
-  }
-  notificationData = setThing(notificationData, notification);
-  return Object.assign(notificationData, {
-    notification: isThingLocal(notification)
-      ? notification.localSubject
-      : notification.url,
-  });
+  return notification;
 }
 
 /**
  * Send a notification to a given target inbox, without performing any discovery.
  *
- * @param notification The [[LitDataset]] containing the notification data.
+ * Note that you will need to manually set a https://www.w3.org/ns/activitystreams#target.
+ *
+ * @param notification The [[Thing]] containing the notification data - see [[unstable_buildNotification]].
  * @param inbox URL of the target inbox.
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  * @returns A Promise resolving to a [[LitDataset]] containing the stored data linked to the new notification Resource, or rejecting if saving it failed.
  */
 export async function unstable_sendNotificationToInbox(
-  notification: LitDataset,
+  notification: Thing,
   inbox: Url | UrlString,
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
 ): Promise<LitDataset & WithResourceInfo> {
+  let litDataset = createLitDataset();
+  litDataset = setThing(litDataset, notification);
+
   return saveLitDatasetInContainer(
     internal_toString(inbox),
     notification,
@@ -159,32 +161,38 @@ export async function unstable_sendNotificationToInbox(
 /**
  * Discovers the inbox of the provided target resource, and then sends the provided notification to that inbox.
  * Fails if no inbox is discovered.
- * @param notification The content of thoe notification
- * @param receiver The target resource (e.g. a WebID)
+ *
+ * @param notification The content of the notification.
+ * @param receiver The URL of the target resource.
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
- * @returns A Promise resolving to a [[LitDataset]] containing the stored data linked to the new notification Resource, or rejecting if saving it failed.
+ * @returns A Promise resolving to a [[Thing]] containing the stored data linked to the new notification Resource, or rejecting if saving it failed.
  */
 export async function unstable_sendNotification(
-  notification: LitDataset & Partial<{ notification: UrlString | LocalNode }>,
+  notification: Thing,
   receiver: Url | UrlString,
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
 ) {
-  let notificationToSend = notification;
   const inbox = await unstable_fetchInbox(receiver, options);
   if (inbox === null) {
     throw new Error(
-      `No inbox discovered for resource [${internal_toString(receiver)}]`
+      `No inbox discovered for Resource [${internal_toString(receiver)}]`
     );
   }
-  if (notification.notification !== undefined) {
-    let notificationThing = getThingOne(
-      notification,
-      notification.notification
-    );
-    notificationThing = setIri(notificationThing, as.target, receiver);
-    notificationToSend = setThing(notificationToSend, notificationThing);
-  }
-  return unstable_sendNotificationToInbox(notificationToSend, inbox, options);
+
+  const notificationWithTarget = setIri(
+    notification,
+    as.target,
+    internal_toString(receiver)
+  );
+
+  let litDataset = createLitDataset();
+  litDataset = setThing(litDataset, notificationWithTarget);
+
+  return unstable_sendNotificationToInbox(
+    notificationWithTarget,
+    inbox,
+    options
+  );
 }

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -344,7 +344,3 @@ function parseWacAllowHeader(wacAllowHeader: string) {
     public: parsePermissionStatement(getStatementFor(wacAllowHeader, "public")),
   };
 }
-
-export function internal_toString(iri: Iri | IriString): string {
-  return typeof iri === "string" ? iri : iri.value;
-}

--- a/src/thing.ts
+++ b/src/thing.ts
@@ -322,6 +322,11 @@ export function isThingLocal(
  * @param thing The Thing whose Subject Node you're interested in.
  * @returns A Node that can be used as the Subject for this Thing's Quads.
  */
+export function toNode(thing: UrlString | Url | ThingPersisted): NamedNode;
+export function toNode(thing: LocalNode | ThingLocal): LocalNode;
+export function toNode(
+  thing: UrlString | Url | LocalNode | Thing
+): NamedNode | LocalNode;
 export function toNode(
   thing: UrlString | Url | LocalNode | Thing
 ): NamedNode | LocalNode {


### PR DESCRIPTION
This PR modifies our syntactic sugar for notifications to only support building and sending a Notification consisting of a single Thing. This removes a lot of complexity, making the common case easier. The complex case of sending a Notification consisting of multiple Things is still served by our existing API for creating and sending multiple Things, which is about as complex as it was previously.

That means that:

- `buildNotification` now returns a `Thing` (without a `target` set).
- `sendNotification` now takes a `Thing` and automatically sets the correct `target`.
- `sendNotificationToInbox` now takes a `Thing` and expects the caller to set the `target`.

The thing I was most unsure about is the return value of those latter two: it currently returns the LitDataset containing the Notification, but maybe it should return just the Thing?

I've also extended the ability to pass NamedNodes to _all_ functions that fetch, as that was already done for the notification sending: 1424e7dcb31bc1dd7777b4958c383355e2f92603

Additionally, I've added the ability to use a Thing as the target for a Notification (i.e. look up the `ldn:inbox` on that `Thing`). That said, this currently works by converting it to a URL and then fetching it again - a future optimisation would be to have `discoverInbox` detect that it's being passed a `Thing` and just read the Predicate from it directly, before trying to fetch it.

# Checklist

- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable. (Only API docs.)
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
