### PR TITLE
Add initial documentation on setting access

### DIFF
--- a/website/docs/glossary.mdx
+++ b/website/docs/glossary.mdx
@@ -50,6 +50,22 @@ An **Access Control List**. For an overview of how they work in Solid, see
 
 A term with which we typically mean a person, but which could also refer to e.g. bots.
 
+#### Default access
+
+[Access](#access) rules that apply not to the [Container](#container) Resource directly, but recursively to its
+children, their children if applicable, so on and so forth.
+
+#### Fallback ACL
+
+If a Resource does not have [an ACL that applies to it directly](#resource-acl), the fallback ACL is
+the ACL of the Container closest to that Resource that has its own Resource ACL. Only the [default
+access](#default-access) rules in the fallback ACL apply.
+
+#### Resource ACL
+
+The [ACL](#acl) that applies to a given Resource. If none exists, the [fallback ACL](#fallback-acl)
+applies.
+
 ### Data
 
 See also the tutorial [Working with Data](./tutorials/working-with-data.md).

--- a/website/docs/tutorials/managing-access.md
+++ b/website/docs/tutorials/managing-access.md
@@ -123,19 +123,152 @@ const accessByAgent = unstable_getAgentAccessAll(litDatasetWithAcl);
 
 ## Changing who has access
 
-:::caution
-
-This section is still being written.
-
-:::
+To be able to _change_ who has access to a specific Resource, you will need to know a little bit
+more about how Access Control works in Solid:
 
 ### Two types of ACL
 
 A Resource _can_ have an ACL that applies to just that Resource. However, if no such ACL exists, the
-Pod server will fall back to the ACL of its [Container](../glossary.mdx#container) — or its Container's
-Container's, or its Container's Container's Container's, etc.
+Pod server will [fall back](../glossary.mdx#fallback-acl) to the ACL of its
+[Container](../glossary.mdx#container) — or its Container's Container's, or its Container's
+Container's Container's, etc.
 
 Thus, an ACL can control both access to a specific Resource or Container directly, and provide
 _default_ access rules: those that apply to the _children_ of the applicable Container when it
 serves as their fallback ACL. Note that the Container's _Resource_ access rules will _not_ apply to
 its children.
+
+### Modifying the ACL
+
+To modify access to a Resource, you will need to obtain its ACL. Assuming you have fetched the
+Resource using
+[`unstable_fetchLitDatasetWithAcl`](../api/modules/_resource_litdataset_.md#unstable_fetchlitdatasetwithacl),
+you can call
+[`unstable_getResourceACL`](../api/modules/_acl_acl_.md#unstable_getresourceacl) to obtain its ACL — or
+`null` if it does not exist.
+
+If it exists, that's great, and you can move on to the next section. You can create a new ACL if it
+does not exist yet, but be aware that doing so will result in overriding any access currently granted
+to the Resource via the default access rules of its fallback ACL, as described in the previous
+section.
+
+A new empty ACL can be initialised using
+[`unstable_createAcl`](api/modules/_acl_acl_.md#unstable_createacl), given that the current user has
+the rights to do so (i.e. [Control](../glossary.mdx#control-access) access on the target Resource).
+However, keep in mind that this ACL will override any ACL that currently applies to it. The
+consequence is that if you do not give someone Control access before saving it to the Pod, nobody
+will ever be able to modify the ACL ever again, which might result in losing access to some data in
+the Pod.
+
+If the fallback ACL is available to the current user, it is possible to copy the currently
+applicable rules to a newly-initialised ACL; but be aware that future updates to the fallback ACL
+will not be reflected in the new ACL.
+
+The general process of changing access to a Resource is as follows:
+
+```typescript
+import {
+  unstable_fetchLitDatasetWithAcl,
+  unstable_hasResourceAcl,
+  unstable_hasFallbackAcl,
+  unstable_hasAccessibleAcl,
+  unstable_createAcl,
+  unstable_createAclFromFallbackAcl,
+  unstable_getResourceAcl,
+  unstable_setAgentResourceAccess,
+  unstable_saveAclFor,
+} from "@solid/lit-pod";
+
+// Fetch the LitDataset and its associated ACLs, if available:
+const litDatasetWithAcl = await unstable_fetchLitDatasetWithAcl(
+  "https://example.com"
+);
+
+// Obtain the LitDataset's own ACL, if available,
+// or initialise a new one, if possible:
+let resourceAcl;
+if (!unstable_hasResourceAcl(litDatasetWithAcl)) {
+  if (!unstable_hasAccessibleAcl(litDatasetWithAcl)) {
+    throw new Error(
+      "The current user does not have permission to change access rights to this Resource."
+    );
+  }
+  if (!unstable_hasFallbackAcl(litDatasetWithAcl)) {
+    throw new Error(
+      "The current user does not have permission to see who currently has access to this Resource."
+    );
+    // Alternatively, initialise a new empty ACL as follows,
+    // but be aware that if you do not give someone Control access,
+    // **nobody will ever be able to change Access permissions in the future**:
+    // resourceAcl = unstable_createAcl(litDatasetWithAcl);
+  }
+  resourceAcl = unstable_createAclFromFallbackAcl(litDatasetWithAcl);
+} else {
+  resourceAcl = unstable_getResourceAcl(litDatasetWithAcl);
+}
+
+// Give someone Control access to the given Resource:
+const updatedAcl = unstable_setAgentResourceAccess(
+  resourceAcl,
+  "https://some.pod/profile#webId",
+  { read: false, append: false, write: false, control: true }
+);
+
+// Now save the ACL:
+await unstable_saveAclFor(litDatasetWithAcl, updatedAcl);
+```
+
+### Setting public access
+
+:::note
+
+lit-pod currently does not support setting public access.
+
+:::
+
+### Setting agent access
+
+Given a Resource's ACL obtained as [described previously](#modifying-the-acl), you can grant Access
+Modes to an Agent for the Resource itself, and/or to its children if the Resource is a Container.
+
+To do the former, use
+[`unstable_setAgentResourceAccess`](../api/modules/_acl_agent_.md#unstable_setagentresourceaccess):
+
+```typescript
+import {
+  unstable_setAgentResourceAccess,
+} from "@solid/lit-pod";
+
+const resourceAcl = /* Obtained previously as described above: */;
+const webId = "https://example.com/profile#webid";
+
+const updatedAcl = unstable_setAgentResourceAccess(
+  resourceAcl,
+  webId,
+  { read: true, append: true, write: false, control: false },
+);
+
+// `updatedAcl` can now be saved back to the Pod
+// using `unstable_saveAclFor()`.
+```
+
+To grant Access Modes to the Agent for the Resource's children, use
+[`unstable_setAgentDefaultAccess`](../api/modules/_acl_agent_.md#unstable_setagentdefaultaccess):
+
+```typescript
+import {
+  unstable_setAgentDefaultAccess,
+} from "@solid/lit-pod";
+
+const resourceAcl = /* Obtained previously as described above: */;
+const webId = "https://example.com/profile#webid";
+
+const updatedAcl = unstable_setAgentDefaultAccess(
+  resourceAcl,
+  webId,
+  { read: true, append: true, write: false, control: false },
+);
+
+// `updatedAcl` can now be saved back to the Pod
+// using `unstable_saveAclFor()`.
+```


### PR DESCRIPTION
# New feature description

This adds an initial shot at documentation on how to actually give an Agent access to a Resource, and most importantly, how to initialise a new ACL if it does not exist yet.

It is quite convoluted, partly because the process itself just is really convoluted, and partly because it's just hard for me to explain.

The updated documentation can be seen here, the section "Changing who has access" is new: https://lit-pod-nmvg3n9cp.vercel.app/docs/tutorials/managing-access
(Compare with the current version: https://inrupt.github.io/lit-pod/docs/tutorials/managing-access/)

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
