### PR TITLE
Mark internal properties as internal_

### DIFF
--- a/src/acl/acl.test.ts
+++ b/src/acl/acl.test.ts
@@ -70,7 +70,7 @@ function mockResponse(
 describe("fetchResourceAcl", () => {
   it("returns the fetched ACL LitDataset", async () => {
     const sourceDataset: WithResourceInfo = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: true,
         unstable_aclUrl: "https://some.pod/resource.acl",
@@ -88,8 +88,8 @@ describe("fetchResourceAcl", () => {
       fetch: mockFetch,
     });
 
-    expect(fetchedAcl?.accessTo).toBe("https://some.pod/resource");
-    expect(fetchedAcl?.resourceInfo.fetchedFrom).toBe(
+    expect(fetchedAcl?.internal_accessTo).toBe("https://some.pod/resource");
+    expect(fetchedAcl?.internal_resourceInfo.fetchedFrom).toBe(
       "https://some.pod/resource.acl"
     );
     expect(mockFetch.mock.calls).toHaveLength(1);
@@ -98,7 +98,7 @@ describe("fetchResourceAcl", () => {
 
   it("calls the included fetcher by default", async () => {
     const sourceDataset: WithResourceInfo = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: true,
         unstable_aclUrl: "https://some.pod/resource.acl",
@@ -120,7 +120,7 @@ describe("fetchResourceAcl", () => {
 
   it("returns null if the source LitDataset has no known ACL IRI", async () => {
     const sourceDataset: WithResourceInfo = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
         isLitDataset: true,
       },
@@ -133,7 +133,7 @@ describe("fetchResourceAcl", () => {
 
   it("returns null if the ACL was not found", async () => {
     const sourceDataset: WithResourceInfo = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
         isLitDataset: true,
         unstable_aclUrl: "https://some.pod/resource.acl",
@@ -161,7 +161,7 @@ describe("fetchResourceAcl", () => {
 describe("fetchFallbackAcl", () => {
   it("returns the parent Container's ACL LitDataset, if present", async () => {
     const sourceDataset = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: true,
         // If no ACL IRI is given, the user does not have Control Access,
@@ -188,8 +188,10 @@ describe("fetchFallbackAcl", () => {
       fetch: mockFetch,
     });
 
-    expect(fetchedAcl?.accessTo).toBe("https://some.pod/");
-    expect(fetchedAcl?.resourceInfo.fetchedFrom).toBe("https://some.pod/.acl");
+    expect(fetchedAcl?.internal_accessTo).toBe("https://some.pod/");
+    expect(fetchedAcl?.internal_resourceInfo.fetchedFrom).toBe(
+      "https://some.pod/.acl"
+    );
     expect(mockFetch.mock.calls).toHaveLength(2);
     expect(mockFetch.mock.calls[0][0]).toBe("https://some.pod/");
     expect(mockFetch.mock.calls[1][0]).toBe("https://some.pod/.acl");
@@ -197,7 +199,7 @@ describe("fetchFallbackAcl", () => {
 
   it("calls the included fetcher by default", async () => {
     const sourceDataset = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: true,
         unstable_aclUrl: "https://some.pod/resource.acl",
@@ -218,7 +220,7 @@ describe("fetchFallbackAcl", () => {
 
   it("travels up multiple levels if no ACL was found on the levels in between", async () => {
     const sourceDataset = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://some.pod/with-acl/without-acl/resource",
         isLitDataset: true,
         // If no ACL IRI is given, the user does not have Control Access,
@@ -266,8 +268,8 @@ describe("fetchFallbackAcl", () => {
       fetch: mockFetch,
     });
 
-    expect(fetchedAcl?.accessTo).toBe("https://some.pod/with-acl/");
-    expect(fetchedAcl?.resourceInfo.fetchedFrom).toBe(
+    expect(fetchedAcl?.internal_accessTo).toBe("https://some.pod/with-acl/");
+    expect(fetchedAcl?.internal_resourceInfo.fetchedFrom).toBe(
       "https://some.pod/with-acl/.acl"
     );
     expect(mockFetch.mock.calls).toHaveLength(4);
@@ -285,7 +287,7 @@ describe("fetchFallbackAcl", () => {
   // not be able to determine the effective ACL:
   it("returns null if one of the Containers on the way up does not advertise an ACL", async () => {
     const sourceDataset = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom:
           "https://some.pod/arbitrary-parent/no-control-access/resource",
         isLitDataset: true,
@@ -317,7 +319,7 @@ describe("fetchFallbackAcl", () => {
 
   it("returns null if no ACL could be found for the Containers up to the root of the Pod", async () => {
     const sourceDataset = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: true,
         // If no ACL IRI is given, the user does not have Control Access,
@@ -360,15 +362,15 @@ describe("fetchFallbackAcl", () => {
 describe("getResourceAcl", () => {
   it("returns the attached Resource ACL Dataset", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      accessTo: "https://arbitrary.pod/resource",
-      resourceInfo: {
+      internal_accessTo: "https://arbitrary.pod/resource",
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
       },
     });
     const litDataset = Object.assign(dataset(), {
-      acl: { resourceAcl: aclDataset, fallbackAcl: null },
-      resourceInfo: {
+      internal_acl: { resourceAcl: aclDataset, fallbackAcl: null },
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
         isLitDataset: true,
         unstable_aclUrl: "https://arbitrary.pod/resource.acl",
@@ -379,15 +381,15 @@ describe("getResourceAcl", () => {
 
   it("returns null if the given Resource does not consider the attached ACL to pertain to it", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      accessTo: "https://arbitrary.pod/resource",
-      resourceInfo: {
+      internal_accessTo: "https://arbitrary.pod/resource",
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
       },
     });
     const litDataset = Object.assign(dataset(), {
-      acl: { resourceAcl: aclDataset, fallbackAcl: null },
-      resourceInfo: {
+      internal_acl: { resourceAcl: aclDataset, fallbackAcl: null },
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
         isLitDataset: true,
         unsafe_aclUrl: "https://arbitrary.pod/other-resource.acl",
@@ -398,15 +400,15 @@ describe("getResourceAcl", () => {
 
   it("returns null if the attached ACL does not pertain to the given Resource", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      accessTo: "https://arbitrary.pod/other-resource",
-      resourceInfo: {
+      internal_accessTo: "https://arbitrary.pod/other-resource",
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
       },
     });
     const litDataset = Object.assign(dataset(), {
-      acl: { resourceAcl: aclDataset, fallbackAcl: null },
-      resourceInfo: {
+      internal_acl: { resourceAcl: aclDataset, fallbackAcl: null },
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
         isLitDataset: true,
         unsafe_aclUrl: "https://arbitrary.pod/resource.acl",
@@ -417,8 +419,8 @@ describe("getResourceAcl", () => {
 
   it("returns null if the given LitDataset does not have a Resource ACL attached", () => {
     const litDataset = Object.assign(dataset(), {
-      acl: { fallbackAcl: null, resourceAcl: null },
-      resourceInfo: {
+      internal_acl: { fallbackAcl: null, resourceAcl: null },
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
         isLitDataset: true,
       },
@@ -430,21 +432,21 @@ describe("getResourceAcl", () => {
 describe("getFallbackAcl", () => {
   it("returns the attached Fallback ACL Dataset", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      accessTo: "https://arbitrary.pod/",
-      resourceInfo: {
+      internal_accessTo: "https://arbitrary.pod/",
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/.acl",
         isLitDataset: true,
       },
     });
     const litDataset = Object.assign(dataset(), {
-      acl: { fallbackAcl: aclDataset, resourceAcl: null },
+      internal_acl: { fallbackAcl: aclDataset, resourceAcl: null },
     });
     expect(unstable_getFallbackAcl(litDataset)).toEqual(aclDataset);
   });
 
   it("returns null if the given LitDataset does not have a Fallback ACL attached", () => {
     const litDataset = Object.assign(dataset(), {
-      acl: { fallbackAcl: null, resourceAcl: null },
+      internal_acl: { fallbackAcl: null, resourceAcl: null },
     });
     expect(unstable_getFallbackAcl(litDataset)).toBeNull();
   });
@@ -453,20 +455,22 @@ describe("getFallbackAcl", () => {
 describe("createAcl", () => {
   it("creates a new empty ACL", () => {
     const litDataset = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://some.pod/container/resource",
         isLitDataset: true,
         unstable_aclUrl: "https://some.pod/container/resource.acl",
       },
-      acl: { fallbackAcl: null, resourceAcl: null },
+      internal_acl: { fallbackAcl: null, resourceAcl: null },
     });
 
     const resourceAcl = unstable_createAcl(litDataset);
 
     const resourceAclQuads = Array.from(resourceAcl);
     expect(resourceAclQuads).toHaveLength(0);
-    expect(resourceAcl.accessTo).toBe("https://some.pod/container/resource");
-    expect(resourceAcl.resourceInfo.fetchedFrom).toBe(
+    expect(resourceAcl.internal_accessTo).toBe(
+      "https://some.pod/container/resource"
+    );
+    expect(resourceAcl.internal_resourceInfo.fetchedFrom).toBe(
       "https://some.pod/container/resource.acl"
     );
   });
@@ -475,8 +479,8 @@ describe("createAcl", () => {
 describe("createAclFromFallbackAcl", () => {
   it("creates a new ACL including existing default rules as Resource rules", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      accessTo: "https://arbitrary.pod/container/",
-      resourceInfo: {
+      internal_accessTo: "https://arbitrary.pod/container/",
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/container/.acl",
         isLitDataset: true,
       },
@@ -513,12 +517,12 @@ describe("createAclFromFallbackAcl", () => {
       )
     );
     const litDataset = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/container/resource",
         isLitDataset: true,
         unstable_aclUrl: "https://arbitrary.pod/container/resource.acl",
       },
-      acl: { fallbackAcl: aclDataset, resourceAcl: null },
+      internal_acl: { fallbackAcl: aclDataset, resourceAcl: null },
     });
 
     const resourceAcl = unstable_createAclFromFallbackAcl(litDataset);
@@ -531,18 +535,18 @@ describe("createAclFromFallbackAcl", () => {
     expect(resourceAclQuads[3].object.value).toBe(
       "https://arbitrary.pod/container/resource"
     );
-    expect(resourceAcl.accessTo).toBe(
+    expect(resourceAcl.internal_accessTo).toBe(
       "https://arbitrary.pod/container/resource"
     );
-    expect(resourceAcl.resourceInfo.fetchedFrom).toBe(
+    expect(resourceAcl.internal_resourceInfo.fetchedFrom).toBe(
       "https://arbitrary.pod/container/resource.acl"
     );
   });
 
   it("does not copy over Resource rules from the fallback ACL", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      accessTo: "https://arbitrary.pod/container/",
-      resourceInfo: {
+      internal_accessTo: "https://arbitrary.pod/container/",
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/container/.acl",
         isLitDataset: true,
       },
@@ -579,12 +583,12 @@ describe("createAclFromFallbackAcl", () => {
       )
     );
     const litDataset = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/container/resource",
         isLitDataset: true,
         unstable_aclUrl: "https://arbitrary.pod/container/resource.acl",
       },
-      acl: { fallbackAcl: aclDataset, resourceAcl: null },
+      internal_acl: { fallbackAcl: aclDataset, resourceAcl: null },
     });
 
     const resourceAcl = unstable_createAclFromFallbackAcl(litDataset);
@@ -597,11 +601,11 @@ describe("createAclFromFallbackAcl", () => {
 describe("getAclRules", () => {
   it("only returns Things that represent ACL Rules", () => {
     const aclDataset = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
       },
-      accessTo: "https://arbitrary.pod/resource",
+      internal_accessTo: "https://arbitrary.pod/resource",
     });
 
     aclDataset.add(
@@ -680,17 +684,19 @@ describe("getAclRules", () => {
     const rules = internal_getAclRules(aclDataset);
 
     expect(rules).toHaveLength(2);
-    expect((rules[0] as ThingPersisted).url).toBe(agentClassRuleSubjectIri);
-    expect((rules[1] as ThingPersisted).url).toBe(agentRuleSubjectIri);
+    expect((rules[0] as ThingPersisted).internal_url).toBe(
+      agentClassRuleSubjectIri
+    );
+    expect((rules[1] as ThingPersisted).internal_url).toBe(agentRuleSubjectIri);
   });
 
   it("returns Things with multiple `rdf:type`s, as long as at least on type is `acl:Authorization`", () => {
     const aclDataset = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
       },
-      accessTo: "https://arbitrary.pod/resource",
+      internal_accessTo: "https://arbitrary.pod/resource",
     });
 
     const ruleWithMultipleTypesSubjectIri =
@@ -738,7 +744,7 @@ describe("getAclRules", () => {
     const rules = internal_getAclRules(aclDataset);
 
     expect(rules).toHaveLength(1);
-    expect((rules[0] as ThingPersisted).url).toBe(
+    expect((rules[0] as ThingPersisted).internal_url).toBe(
       ruleWithMultipleTypesSubjectIri
     );
   });
@@ -747,7 +753,7 @@ describe("getAclRules", () => {
 describe("getResourceAclRules", () => {
   it("only returns ACL Rules that apply to a Resource", () => {
     const resourceAclRule1: unstable_AclRule = Object.assign(dataset(), {
-      url: "https://arbitrary.pod/resource.acl#rule1",
+      internal_url: "https://arbitrary.pod/resource.acl#rule1",
     });
     resourceAclRule1.add(
       DataFactory.quad(
@@ -758,7 +764,7 @@ describe("getResourceAclRules", () => {
     );
 
     const defaultAclRule1: unstable_AclRule = Object.assign(dataset(), {
-      url: "https://arbitrary.pod/container/.acl#rule2",
+      internal_url: "https://arbitrary.pod/container/.acl#rule2",
     });
     defaultAclRule1.add(
       DataFactory.quad(
@@ -769,7 +775,7 @@ describe("getResourceAclRules", () => {
     );
 
     const resourceAclRule2: unstable_AclRule = Object.assign(dataset(), {
-      url: "https://arbitrary.pod/resource.acl#rule3",
+      internal_url: "https://arbitrary.pod/resource.acl#rule3",
     });
     resourceAclRule2.add(
       DataFactory.quad(
@@ -780,7 +786,7 @@ describe("getResourceAclRules", () => {
     );
 
     const defaultAclRule2: unstable_AclRule = Object.assign(dataset(), {
-      url: "https://arbitrary.pod/container/.acl#rule4",
+      internal_url: "https://arbitrary.pod/container/.acl#rule4",
     });
     defaultAclRule2.add(
       DataFactory.quad(
@@ -806,7 +812,7 @@ describe("getResourceAclRules", () => {
 describe("getResourceAclRulesForResource", () => {
   it("only returns ACL Rules that apply to a given Resource", () => {
     const targetResourceAclRule: unstable_AclRule = Object.assign(dataset(), {
-      url: "https://arbitrary.pod/resource.acl#rule1",
+      internal_url: "https://arbitrary.pod/resource.acl#rule1",
     });
     targetResourceAclRule.add(
       DataFactory.quad(
@@ -817,7 +823,7 @@ describe("getResourceAclRulesForResource", () => {
     );
 
     const defaultAclRule: unstable_AclRule = Object.assign(dataset(), {
-      url: "https://arbitrary.pod/container/.acl#rule2",
+      internal_url: "https://arbitrary.pod/container/.acl#rule2",
     });
     defaultAclRule.add(
       DataFactory.quad(
@@ -828,7 +834,7 @@ describe("getResourceAclRulesForResource", () => {
     );
 
     const otherResourceAclRule: unstable_AclRule = Object.assign(dataset(), {
-      url: "https://arbitrary.pod/resource.acl#rule3",
+      internal_url: "https://arbitrary.pod/resource.acl#rule3",
     });
     otherResourceAclRule.add(
       DataFactory.quad(
@@ -856,7 +862,7 @@ describe("getResourceAclRulesForResource", () => {
 describe("getDefaultAclRules", () => {
   it("only returns ACL Rules that are the default for a Container", () => {
     const resourceAclRule1: unstable_AclRule = Object.assign(dataset(), {
-      url: "https://arbitrary.pod/resource.acl#rule1",
+      internal_url: "https://arbitrary.pod/resource.acl#rule1",
     });
     resourceAclRule1.add(
       DataFactory.quad(
@@ -867,7 +873,7 @@ describe("getDefaultAclRules", () => {
     );
 
     const defaultAclRule1: unstable_AclRule = Object.assign(dataset(), {
-      url: "https://arbitrary.pod/container/.acl#rule2",
+      internal_url: "https://arbitrary.pod/container/.acl#rule2",
     });
     defaultAclRule1.add(
       DataFactory.quad(
@@ -878,7 +884,7 @@ describe("getDefaultAclRules", () => {
     );
 
     const resourceAclRule2: unstable_AclRule = Object.assign(dataset(), {
-      url: "https://arbitrary.pod/resource.acl#rule3",
+      internal_url: "https://arbitrary.pod/resource.acl#rule3",
     });
     resourceAclRule2.add(
       DataFactory.quad(
@@ -889,7 +895,7 @@ describe("getDefaultAclRules", () => {
     );
 
     const defaultAclRule2: unstable_AclRule = Object.assign(dataset(), {
-      url: "https://arbitrary.pod/container/.acl#rule4",
+      internal_url: "https://arbitrary.pod/container/.acl#rule4",
     });
     defaultAclRule2.add(
       DataFactory.quad(
@@ -915,7 +921,7 @@ describe("getDefaultAclRules", () => {
 describe("getDefaultAclRulesForResource", () => {
   it("only returns ACL Rules that are the default for children of a given Container", () => {
     const resourceAclRule: unstable_AclRule = Object.assign(dataset(), {
-      url: "https://arbitrary.pod/resource.acl#rule1",
+      internal_url: "https://arbitrary.pod/resource.acl#rule1",
     });
     resourceAclRule.add(
       DataFactory.quad(
@@ -926,7 +932,7 @@ describe("getDefaultAclRulesForResource", () => {
     );
 
     const targetDefaultAclRule: unstable_AclRule = Object.assign(dataset(), {
-      url: "https://arbitrary.pod/container/.acl#rule2",
+      internal_url: "https://arbitrary.pod/container/.acl#rule2",
     });
     targetDefaultAclRule.add(
       DataFactory.quad(
@@ -937,7 +943,7 @@ describe("getDefaultAclRulesForResource", () => {
     );
 
     const otherDefaultAclRule: unstable_AclRule = Object.assign(dataset(), {
-      url: "https://arbitrary.pod/container/.acl#rule3",
+      internal_url: "https://arbitrary.pod/container/.acl#rule3",
     });
     otherDefaultAclRule.add(
       DataFactory.quad(
@@ -966,7 +972,7 @@ describe("getAccess", () => {
   it("returns true for Access Modes that are granted", () => {
     const subject = "https://arbitrary.pod/profileDoc#webId";
 
-    const mockRule = Object.assign(dataset(), { url: subject });
+    const mockRule = Object.assign(dataset(), { internal_url: subject });
     mockRule.add(
       DataFactory.quad(
         DataFactory.namedNode(subject),
@@ -1007,7 +1013,7 @@ describe("getAccess", () => {
   it("returns false for undefined Access Modes", () => {
     const subject = "https://arbitrary.pod/profileDoc#webId";
 
-    const mockRule = Object.assign(dataset(), { url: subject });
+    const mockRule = Object.assign(dataset(), { internal_url: subject });
 
     expect(internal_getAccess(mockRule)).toEqual({
       read: false,
@@ -1020,7 +1026,7 @@ describe("getAccess", () => {
   it("infers Append access from Write access", () => {
     const subject = "https://arbitrary.pod/profileDoc#webId";
 
-    const mockRule = Object.assign(dataset(), { url: subject });
+    const mockRule = Object.assign(dataset(), { internal_url: subject });
     mockRule.add(
       DataFactory.quad(
         DataFactory.namedNode(subject),
@@ -1098,11 +1104,11 @@ describe("combineAccessModes", () => {
 describe("removeEmptyAclRules", () => {
   it("removes rules that do not apply to anyone", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
       },
-      accessTo: "https://arbitrary.pod/resource",
+      internal_accessTo: "https://arbitrary.pod/resource",
     });
     const subjectIri = "https://arbitrary.pod/resource.acl#emptyRule";
     aclDataset.add(
@@ -1136,11 +1142,11 @@ describe("removeEmptyAclRules", () => {
 
   it("does not modify the input LitDataset", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
       },
-      accessTo: "https://arbitrary.pod/resource",
+      internal_accessTo: "https://arbitrary.pod/resource",
     });
     const subjectIri = "https://arbitrary.pod/resource.acl#emptyRule";
     aclDataset.add(
@@ -1175,11 +1181,11 @@ describe("removeEmptyAclRules", () => {
 
   it("removes rules that do not set any Access Modes", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
       },
-      accessTo: "https://arbitrary.pod/resource",
+      internal_accessTo: "https://arbitrary.pod/resource",
     });
     const subjectIri = "https://arbitrary.pod/resource.acl#emptyRule";
     aclDataset.add(
@@ -1213,11 +1219,11 @@ describe("removeEmptyAclRules", () => {
 
   it("removes rules that do not have target Resources to which they apply", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
       },
-      accessTo: "https://arbitrary.pod/resource",
+      internal_accessTo: "https://arbitrary.pod/resource",
     });
     const subjectIri = "https://arbitrary.pod/resource.acl#emptyRule";
     aclDataset.add(
@@ -1251,11 +1257,11 @@ describe("removeEmptyAclRules", () => {
 
   it("removes rules that specify an acl:origin but not in combination with an Agent, Agent Group or Agent Class", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
       },
-      accessTo: "https://arbitrary.pod/resource",
+      internal_accessTo: "https://arbitrary.pod/resource",
     });
     const subjectIri = "https://arbitrary.pod/resource.acl#emptyRule";
     aclDataset.add(
@@ -1296,11 +1302,11 @@ describe("removeEmptyAclRules", () => {
 
   it("does not remove Rules that are also something other than an ACL Rule", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
       },
-      accessTo: "https://arbitrary.pod/resource",
+      internal_accessTo: "https://arbitrary.pod/resource",
     });
     const subjectIri = "https://arbitrary.pod/resource.acl#rule";
     aclDataset.add(
@@ -1350,11 +1356,11 @@ describe("removeEmptyAclRules", () => {
 
   it("does not remove Things that are Rules but also have other Quads", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
       },
-      accessTo: "https://arbitrary.pod/resource",
+      internal_accessTo: "https://arbitrary.pod/resource",
     });
     const subjectIri = "https://arbitrary.pod/resource.acl#rule";
     aclDataset.add(
@@ -1402,11 +1408,11 @@ describe("removeEmptyAclRules", () => {
 
   it("does not remove Rules that apply to a Container's child Resources", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/container/.acl",
         isLitDataset: true,
       },
-      accessTo: "https://arbitrary.pod/container/",
+      internal_accessTo: "https://arbitrary.pod/container/",
     });
     const subjectIri = "https://arbitrary.pod/container/.acl#rule";
     aclDataset.add(
@@ -1447,11 +1453,11 @@ describe("removeEmptyAclRules", () => {
 
   it("does not remove Rules that apply to an Agent", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
       },
-      accessTo: "https://arbitrary.pod/resource",
+      internal_accessTo: "https://arbitrary.pod/resource",
     });
     const subjectIri = "https://arbitrary.pod/resource.acl#rule";
     aclDataset.add(
@@ -1492,11 +1498,11 @@ describe("removeEmptyAclRules", () => {
 
   it("does not remove Rules that apply to an Agent Group", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
       },
-      accessTo: "https://arbitrary.pod/resource",
+      internal_accessTo: "https://arbitrary.pod/resource",
     });
     const subjectIri = "https://arbitrary.pod/resource.acl#rule";
     aclDataset.add(
@@ -1537,11 +1543,11 @@ describe("removeEmptyAclRules", () => {
 
   it("does not remove Rules that apply to an Agent Class", () => {
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
       },
-      accessTo: "https://arbitrary.pod/resource",
+      internal_accessTo: "https://arbitrary.pod/resource",
     });
     const subjectIri = "https://arbitrary.pod/resource.acl#rule";
     aclDataset.add(
@@ -1590,18 +1596,18 @@ describe("saveAclFor", () => {
       >;
     };
     const withResourceInfo = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
         isLitDataset: true,
         unstable_aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
       },
-      accessTo: "https://arbitrary.pod/resource",
+      internal_accessTo: "https://arbitrary.pod/resource",
     });
 
     await unstable_saveAclFor(withResourceInfo, aclResource);
@@ -1614,18 +1620,18 @@ describe("saveAclFor", () => {
       .fn(window.fetch)
       .mockReturnValue(Promise.resolve(new Response()));
     const withResourceInfo = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
         isLitDataset: true,
         unstable_aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
       },
-      accessTo: "https://arbitrary.pod/resource",
+      internal_accessTo: "https://arbitrary.pod/resource",
     });
 
     await unstable_saveAclFor(withResourceInfo, aclResource, {
@@ -1642,18 +1648,18 @@ describe("saveAclFor", () => {
         Promise.resolve(new Response("Not allowed", { status: 403 }))
       );
     const withResourceInfo = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
         isLitDataset: true,
         unstable_aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
       },
-      accessTo: "https://arbitrary.pod/resource",
+      internal_accessTo: "https://arbitrary.pod/resource",
     });
 
     const fetchPromise = unstable_saveAclFor(withResourceInfo, aclResource, {
@@ -1670,25 +1676,25 @@ describe("saveAclFor", () => {
       .fn(window.fetch)
       .mockReturnValue(Promise.resolve(new Response()));
     const withResourceInfo = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: true,
         unstable_aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
       },
-      accessTo: "https://some-other.pod/resource",
+      internal_accessTo: "https://some-other.pod/resource",
     });
 
     const savedAcl = await unstable_saveAclFor(withResourceInfo, aclResource, {
       fetch: mockFetch,
     });
 
-    expect(savedAcl.accessTo).toBe("https://some.pod/resource");
+    expect(savedAcl.internal_accessTo).toBe("https://some.pod/resource");
   });
 
   it("sends a PATCH if the ACL contains a ChangeLog and was originally fetched from the same location", async () => {
@@ -1696,19 +1702,19 @@ describe("saveAclFor", () => {
       .fn(window.fetch)
       .mockReturnValue(Promise.resolve(new Response()));
     const withResourceInfo = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
         isLitDataset: true,
         unstable_aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
       },
-      accessTo: "https://arbitrary.pod/resource",
-      changeLog: {
+      internal_accessTo: "https://arbitrary.pod/resource",
+      internal_changeLog: {
         additions: [],
         deletions: [],
       },
@@ -1726,19 +1732,19 @@ describe("saveAclFor", () => {
       .fn(window.fetch)
       .mockReturnValue(Promise.resolve(new Response()));
     const withResourceInfo = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
         isLitDataset: true,
         unstable_aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: unstable_AclDataset = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary-other.pod/resource.acl",
         isLitDataset: true,
       },
-      accessTo: "https://arbitrary.pod/resource",
-      changeLog: {
+      internal_accessTo: "https://arbitrary.pod/resource",
+      internal_changeLog: {
         additions: [],
         deletions: [],
       },
@@ -1761,7 +1767,7 @@ describe("deleteAclFor", () => {
       >;
     };
     const mockResource: WithResourceInfo & unstable_WithAccessibleAcl = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: false,
         unstable_aclUrl: "https://some.pod/resource.acl",
@@ -1786,7 +1792,7 @@ describe("deleteAclFor", () => {
       .mockReturnValue(Promise.resolve(new Response()));
 
     const mockResource: WithResourceInfo & unstable_WithAccessibleAcl = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: false,
         unstable_aclUrl: "https://some.pod/resource.acl",
@@ -1811,7 +1817,7 @@ describe("deleteAclFor", () => {
       .mockReturnValue(Promise.resolve(new Response()));
 
     const mockResource: WithResourceInfo & unstable_WithAccessibleAcl = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: false,
         unstable_aclUrl: "https://some.pod/resource.acl",
@@ -1833,7 +1839,7 @@ describe("deleteAclFor", () => {
       );
 
     const mockResource: WithResourceInfo & unstable_WithAccessibleAcl = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: false,
         unstable_aclUrl: "https://some.pod/resource.acl",
@@ -1857,7 +1863,7 @@ describe("deleteAclFor", () => {
       );
 
     const mockResource: WithResourceInfo & unstable_WithAccessibleAcl = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: false,
         unstable_aclUrl: "https://some.pod/resource.acl",

--- a/src/acl/agent.test.ts
+++ b/src/acl/agent.test.ts
@@ -112,7 +112,7 @@ function addAclRuleQuads(
     );
   }
 
-  return Object.assign(aclDataset, { accessTo: resource });
+  return Object.assign(aclDataset, { internal_accessTo: resource });
 }
 
 function addAclDatasetToLitDataset(
@@ -120,25 +120,25 @@ function addAclDatasetToLitDataset(
   aclDataset: unstable_AclDataset,
   type: "resource" | "fallback"
 ): LitDataset & WithResourceInfo & unstable_WithAcl {
-  const acl: unstable_WithAcl["acl"] = {
+  const acl: unstable_WithAcl["internal_acl"] = {
     fallbackAcl: null,
     resourceAcl: null,
-    ...(((litDataset as any) as unstable_WithAcl).acl ?? {}),
+    ...(((litDataset as any) as unstable_WithAcl).internal_acl ?? {}),
   };
   if (type === "resource") {
-    litDataset.resourceInfo.unstable_aclUrl =
-      aclDataset.resourceInfo.fetchedFrom;
-    aclDataset.accessTo = litDataset.resourceInfo.fetchedFrom;
+    litDataset.internal_resourceInfo.unstable_aclUrl =
+      aclDataset.internal_resourceInfo.fetchedFrom;
+    aclDataset.internal_accessTo = litDataset.internal_resourceInfo.fetchedFrom;
     acl.resourceAcl = aclDataset;
   } else if (type === "fallback") {
     acl.fallbackAcl = aclDataset;
   }
-  return Object.assign(litDataset, { acl: acl });
+  return Object.assign(litDataset, { internal_acl: acl });
 }
 
 function getMockDataset(fetchedFrom: IriString): LitDataset & WithResourceInfo {
   return Object.assign(dataset(), {
-    resourceInfo: {
+    internal_resourceInfo: {
       fetchedFrom: fetchedFrom,
       isLitDataset: true,
     },
@@ -205,7 +205,7 @@ describe("getAgentAccessOne", () => {
   it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
     const litDataset = getMockDataset("https://some.pod/container/resource");
     const inaccessibleAcl: unstable_WithAcl = {
-      acl: { fallbackAcl: null, resourceAcl: null },
+      internal_acl: { fallbackAcl: null, resourceAcl: null },
     };
     const litDatasetWithInaccessibleAcl = Object.assign(
       litDataset,
@@ -389,7 +389,7 @@ describe("getAgentAccessAll", () => {
   it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
     const litDataset = getMockDataset("https://some.pod/container/resource");
     const inaccessibleAcl: unstable_WithAcl = {
-      acl: { fallbackAcl: null, resourceAcl: null },
+      internal_acl: { fallbackAcl: null, resourceAcl: null },
     };
     const litDatasetWithInaccessibleAcl = Object.assign(
       litDataset,
@@ -859,7 +859,7 @@ describe("setAgentResourceAccess", () => {
   it("adds Quads for the appropriate Access Modes", () => {
     const sourceDataset = Object.assign(
       getMockDataset("https://arbitrary.pod/resource.acl"),
-      { accessTo: "https://arbitrary.pod/resource" }
+      { internal_accessTo: "https://arbitrary.pod/resource" }
     );
 
     const updatedDataset = unstable_setAgentResourceAccess(
@@ -914,7 +914,7 @@ describe("setAgentResourceAccess", () => {
   it("does not alter the input LitDataset", () => {
     const sourceDataset = Object.assign(
       getMockDataset("https://arbitrary.pod/resource.acl"),
-      { accessTo: "https://arbitrary.pod/resource" }
+      { internal_accessTo: "https://arbitrary.pod/resource" }
     );
 
     unstable_setAgentResourceAccess(
@@ -934,7 +934,7 @@ describe("setAgentResourceAccess", () => {
   it("keeps a log of changes made to the ACL", () => {
     const sourceDataset = Object.assign(
       getMockDataset("https://arbitrary.pod/resource.acl"),
-      { accessTo: "https://arbitrary.pod/resource" }
+      { internal_accessTo: "https://arbitrary.pod/resource" }
     );
 
     const updatedDataset = unstable_setAgentResourceAccess(
@@ -948,9 +948,9 @@ describe("setAgentResourceAccess", () => {
       }
     );
 
-    const deletedQuads = updatedDataset.changeLog.deletions;
+    const deletedQuads = updatedDataset.internal_changeLog.deletions;
     expect(deletedQuads).toEqual([]);
-    const addedQuads = updatedDataset.changeLog.additions;
+    const addedQuads = updatedDataset.internal_changeLog.additions;
     expect(addedQuads).toHaveLength(4);
     expect(addedQuads[0].predicate.value).toBe(
       "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
@@ -982,7 +982,7 @@ describe("setAgentResourceAccess", () => {
     // (but we should be able to leave that to the server).
     const sourceDataset = Object.assign(
       getMockDataset("https://arbitrary.pod/resource.acl"),
-      { accessTo: "https://arbitrary.pod/resource" }
+      { internal_accessTo: "https://arbitrary.pod/resource" }
     );
 
     const updatedDataset = unstable_setAgentResourceAccess(
@@ -1700,7 +1700,7 @@ describe("setAgentDefaultAccess", () => {
   it("adds Quads for the appropriate Access Modes", () => {
     const sourceDataset = Object.assign(
       getMockDataset("https://arbitrary.pod/container/.acl"),
-      { accessTo: "https://arbitrary.pod/container/" }
+      { internal_accessTo: "https://arbitrary.pod/container/" }
     );
 
     const updatedDataset = unstable_setAgentDefaultAccess(
@@ -1757,7 +1757,7 @@ describe("setAgentDefaultAccess", () => {
   it("does not alter the input LitDataset", () => {
     const sourceDataset = Object.assign(
       getMockDataset("https://arbitrary.pod/container/.acl"),
-      { accessTo: "https://arbitrary.pod/container/" }
+      { internal_accessTo: "https://arbitrary.pod/container/" }
     );
 
     unstable_setAgentDefaultAccess(
@@ -1777,7 +1777,7 @@ describe("setAgentDefaultAccess", () => {
   it("keeps a log of changes made to the ACL", () => {
     const sourceDataset = Object.assign(
       getMockDataset("https://arbitrary.pod/container/.acl"),
-      { accessTo: "https://arbitrary.pod/container/" }
+      { internal_accessTo: "https://arbitrary.pod/container/" }
     );
 
     const updatedDataset = unstable_setAgentDefaultAccess(
@@ -1791,9 +1791,9 @@ describe("setAgentDefaultAccess", () => {
       }
     );
 
-    const deletedQuads = updatedDataset.changeLog.deletions;
+    const deletedQuads = updatedDataset.internal_changeLog.deletions;
     expect(deletedQuads).toEqual([]);
-    const addedQuads = updatedDataset.changeLog.additions;
+    const addedQuads = updatedDataset.internal_changeLog.additions;
     expect(addedQuads).toHaveLength(4);
     expect(addedQuads[0].predicate.value).toBe(
       "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
@@ -1825,7 +1825,7 @@ describe("setAgentDefaultAccess", () => {
     // (but we should be able to leave that to the server).
     const sourceDataset = Object.assign(
       getMockDataset("https://arbitrary.pod/container/.acl"),
-      { accessTo: "https://arbitrary.pod/container/" }
+      { internal_accessTo: "https://arbitrary.pod/container/" }
     );
 
     const updatedDataset = unstable_setAgentDefaultAccess(

--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -70,13 +70,13 @@ export function unstable_getAgentAccessOne(
 ): unstable_Access | null {
   if (unstable_hasResourceAcl(resourceInfo)) {
     return unstable_getAgentResourceAccessOne(
-      resourceInfo.acl.resourceAcl,
+      resourceInfo.internal_acl.resourceAcl,
       agent
     );
   }
   if (unstable_hasFallbackAcl(resourceInfo)) {
     return unstable_getAgentDefaultAccessOne(
-      resourceInfo.acl.fallbackAcl,
+      resourceInfo.internal_acl.fallbackAcl,
       agent
     );
   }
@@ -127,7 +127,7 @@ export function unstable_getAgentResourceAccessOne(
   const allRules = internal_getAclRules(aclDataset);
   const resourceRules = internal_getResourceAclRulesForResource(
     allRules,
-    aclDataset.accessTo
+    aclDataset.internal_accessTo
   );
   const agentResourceRules = getAgentAclRulesForAgent(resourceRules, agent);
   const agentAccessModes = agentResourceRules.map(internal_getAccess);
@@ -152,7 +152,7 @@ export function unstable_getAgentResourceAccessAll(
   const allRules = internal_getAclRules(aclDataset);
   const resourceRules = internal_getResourceAclRulesForResource(
     allRules,
-    aclDataset.accessTo
+    aclDataset.internal_accessTo
   );
   const agentResourceRules = getAgentAclRules(resourceRules);
   return getAccessByAgent(agentResourceRules);
@@ -191,7 +191,7 @@ export function unstable_setAgentResourceAccess(
     const [filteredRule, remainingRule] = removeAgentFromResourceRule(
       aclRule,
       agent,
-      aclDataset.accessTo
+      aclDataset.internal_accessTo
     );
     filteredAcl = setThing(filteredAcl, filteredRule);
     filteredAcl = setThing(filteredAcl, remainingRule);
@@ -199,7 +199,7 @@ export function unstable_setAgentResourceAccess(
 
   // Create a new Rule that only grants the given Agent the given Access Modes:
   let newRule = intialiseAclRule(access);
-  newRule = setIri(newRule, acl.accessTo, aclDataset.accessTo);
+  newRule = setIri(newRule, acl.accessTo, aclDataset.internal_accessTo);
   newRule = setIri(newRule, acl.agent, agent);
   const updatedAcl = setThing(filteredAcl, newRule);
 
@@ -229,7 +229,7 @@ export function unstable_getAgentDefaultAccessOne(
   const allRules = internal_getAclRules(aclDataset);
   const resourceRules = internal_getDefaultAclRulesForResource(
     allRules,
-    aclDataset.accessTo
+    aclDataset.internal_accessTo
   );
   const agentResourceRules = getAgentAclRulesForAgent(resourceRules, agent);
   const agentAccessModes = agentResourceRules.map(internal_getAccess);
@@ -254,7 +254,7 @@ export function unstable_getAgentDefaultAccessAll(
   const allRules = internal_getAclRules(aclDataset);
   const resourceRules = internal_getDefaultAclRulesForResource(
     allRules,
-    aclDataset.accessTo
+    aclDataset.internal_accessTo
   );
   const agentResourceRules = getAgentAclRules(resourceRules);
 
@@ -294,7 +294,7 @@ export function unstable_setAgentDefaultAccess(
     const [filteredRule, remainingRule] = removeAgentFromDefaultRule(
       aclRule,
       agent,
-      aclDataset.accessTo
+      aclDataset.internal_accessTo
     );
     filteredAcl = setThing(filteredAcl, filteredRule);
     filteredAcl = setThing(filteredAcl, remainingRule);
@@ -302,7 +302,7 @@ export function unstable_setAgentDefaultAccess(
 
   // Create a new Rule that only grants the given Agent the given default Access Modes:
   let newRule = intialiseAclRule(access);
-  newRule = setIri(newRule, acl.default, aclDataset.accessTo);
+  newRule = setIri(newRule, acl.default, aclDataset.internal_accessTo);
   newRule = setIri(newRule, acl.agent, agent);
   const updatedAcl = setThing(filteredAcl, newRule);
 

--- a/src/acl/class.test.ts
+++ b/src/acl/class.test.ts
@@ -109,7 +109,7 @@ function addAclRuleQuads(
     );
   }
 
-  return Object.assign(aclDataset, { accessTo: resource });
+  return Object.assign(aclDataset, { internal_accessTo: resource });
 }
 
 function addAclDatasetToLitDataset(
@@ -117,25 +117,25 @@ function addAclDatasetToLitDataset(
   aclDataset: unstable_AclDataset,
   type: "resource" | "fallback"
 ): LitDataset & WithResourceInfo & unstable_WithAcl {
-  const acl: unstable_WithAcl["acl"] = {
+  const acl: unstable_WithAcl["internal_acl"] = {
     fallbackAcl: null,
     resourceAcl: null,
-    ...(((litDataset as any) as unstable_WithAcl).acl ?? {}),
+    ...(((litDataset as any) as unstable_WithAcl).internal_acl ?? {}),
   };
   if (type === "resource") {
-    litDataset.resourceInfo.unstable_aclUrl =
-      aclDataset.resourceInfo.fetchedFrom;
-    aclDataset.accessTo = litDataset.resourceInfo.fetchedFrom;
+    litDataset.internal_resourceInfo.unstable_aclUrl =
+      aclDataset.internal_resourceInfo.fetchedFrom;
+    aclDataset.internal_accessTo = litDataset.internal_resourceInfo.fetchedFrom;
     acl.resourceAcl = aclDataset;
   } else if (type === "fallback") {
     acl.fallbackAcl = aclDataset;
   }
-  return Object.assign(litDataset, { acl: acl });
+  return Object.assign(litDataset, { internal_acl: acl });
 }
 
 function getMockDataset(fetchedFrom: IriString): LitDataset & WithResourceInfo {
   return Object.assign(dataset(), {
-    resourceInfo: {
+    internal_resourceInfo: {
       fetchedFrom: fetchedFrom,
       isLitDataset: true,
     },
@@ -196,7 +196,7 @@ describe("getPublicAccess", () => {
   it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
     const litDataset = getMockDataset("https://some.pod/container/resource");
     const inaccessibleAcl: unstable_WithAcl = {
-      acl: { fallbackAcl: null, resourceAcl: null },
+      internal_acl: { fallbackAcl: null, resourceAcl: null },
     };
     const litDatasetWithInaccessibleAcl = Object.assign(
       litDataset,

--- a/src/acl/class.ts
+++ b/src/acl/class.ts
@@ -53,10 +53,14 @@ export function unstable_getPublicAccess(
   resourceInfo: unstable_WithAcl & WithResourceInfo
 ): unstable_Access | null {
   if (unstable_hasResourceAcl(resourceInfo)) {
-    return unstable_getPublicResourceAccess(resourceInfo.acl.resourceAcl);
+    return unstable_getPublicResourceAccess(
+      resourceInfo.internal_acl.resourceAcl
+    );
   }
   if (unstable_hasFallbackAcl(resourceInfo)) {
-    return unstable_getPublicDefaultAccess(resourceInfo.acl.fallbackAcl);
+    return unstable_getPublicDefaultAccess(
+      resourceInfo.internal_acl.fallbackAcl
+    );
   }
   return null;
 }
@@ -79,7 +83,7 @@ export function unstable_getPublicResourceAccess(
   const allRules = internal_getAclRules(aclDataset);
   const resourceRules = internal_getResourceAclRulesForResource(
     allRules,
-    aclDataset.accessTo
+    aclDataset.internal_accessTo
   );
   const publicResourceRules = getClassAclRulesForClass(
     resourceRules,
@@ -107,7 +111,7 @@ export function unstable_getPublicDefaultAccess(
   const allRules = internal_getAclRules(aclDataset);
   const resourceRules = internal_getDefaultAclRulesForResource(
     allRules,
-    aclDataset.accessTo
+    aclDataset.internal_accessTo
   );
   const publicResourceRules = getClassAclRulesForClass(
     resourceRules,

--- a/src/acl/group.test.ts
+++ b/src/acl/group.test.ts
@@ -109,7 +109,7 @@ function addAclRuleQuads(
     );
   }
 
-  return Object.assign(aclDataset, { accessTo: resource });
+  return Object.assign(aclDataset, { internal_accessTo: resource });
 }
 
 function addAclDatasetToLitDataset(
@@ -117,25 +117,25 @@ function addAclDatasetToLitDataset(
   aclDataset: unstable_AclDataset,
   type: "resource" | "fallback"
 ): LitDataset & WithResourceInfo & unstable_WithAcl {
-  const acl: unstable_WithAcl["acl"] = {
+  const acl: unstable_WithAcl["internal_acl"] = {
     fallbackAcl: null,
     resourceAcl: null,
-    ...(((litDataset as any) as unstable_WithAcl).acl ?? {}),
+    ...(((litDataset as any) as unstable_WithAcl).internal_acl ?? {}),
   };
   if (type === "resource") {
-    litDataset.resourceInfo.unstable_aclUrl =
-      aclDataset.resourceInfo.fetchedFrom;
-    aclDataset.accessTo = litDataset.resourceInfo.fetchedFrom;
+    litDataset.internal_resourceInfo.unstable_aclUrl =
+      aclDataset.internal_resourceInfo.fetchedFrom;
+    aclDataset.internal_accessTo = litDataset.internal_resourceInfo.fetchedFrom;
     acl.resourceAcl = aclDataset;
   } else if (type === "fallback") {
     acl.fallbackAcl = aclDataset;
   }
-  return Object.assign(litDataset, { acl: acl });
+  return Object.assign(litDataset, { internal_acl: acl });
 }
 
 function getMockDataset(fetchedFrom: IriString): LitDataset & WithResourceInfo {
   return Object.assign(dataset(), {
-    resourceInfo: {
+    internal_resourceInfo: {
       fetchedFrom: fetchedFrom,
       isLitDataset: true,
     },
@@ -202,7 +202,7 @@ describe("getGroupAccessOne", () => {
   it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
     const litDataset = getMockDataset("https://some.pod/container/resource");
     const inaccessibleAcl: unstable_WithAcl = {
-      acl: { fallbackAcl: null, resourceAcl: null },
+      internal_acl: { fallbackAcl: null, resourceAcl: null },
     };
     const litDatasetWithInaccessibleAcl = Object.assign(
       litDataset,
@@ -386,7 +386,7 @@ describe("getGroupAccessAll", () => {
   it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
     const litDataset = getMockDataset("https://some.pod/container/resource");
     const inaccessibleAcl: unstable_WithAcl = {
-      acl: { fallbackAcl: null, resourceAcl: null },
+      internal_acl: { fallbackAcl: null, resourceAcl: null },
     };
     const litDatasetWithInaccessibleAcl = Object.assign(
       litDataset,

--- a/src/acl/group.ts
+++ b/src/acl/group.ts
@@ -61,13 +61,13 @@ export function unstable_getGroupAccessOne(
 ): unstable_Access | null {
   if (unstable_hasResourceAcl(resourceInfo)) {
     return unstable_getGroupResourceAccessOne(
-      resourceInfo.acl.resourceAcl,
+      resourceInfo.internal_acl.resourceAcl,
       group
     );
   }
   if (unstable_hasFallbackAcl(resourceInfo)) {
     return unstable_getGroupDefaultAccessOne(
-      resourceInfo.acl.fallbackAcl,
+      resourceInfo.internal_acl.fallbackAcl,
       group
     );
   }
@@ -118,7 +118,7 @@ export function unstable_getGroupResourceAccessOne(
   const allRules = internal_getAclRules(aclDataset);
   const resourceRules = internal_getResourceAclRulesForResource(
     allRules,
-    aclDataset.accessTo
+    aclDataset.internal_accessTo
   );
   const groupResourceRules = getGroupAclRuleForGroup(resourceRules, group);
   const groupAccessModes = groupResourceRules.map(internal_getAccess);
@@ -143,7 +143,7 @@ export function unstable_getGroupResourceAccessAll(
   const allRules = internal_getAclRules(aclDataset);
   const resourceRules = internal_getResourceAclRulesForResource(
     allRules,
-    aclDataset.accessTo
+    aclDataset.internal_accessTo
   );
   return getAccessByGroup(resourceRules);
 }
@@ -168,7 +168,7 @@ export function unstable_getGroupDefaultAccessOne(
   const allRules = internal_getAclRules(aclDataset);
   const defaultRules = internal_getDefaultAclRulesForResource(
     allRules,
-    aclDataset.accessTo
+    aclDataset.internal_accessTo
   );
   const groupDefaultRules = getGroupAclRuleForGroup(defaultRules, group);
   const groupAccessModes = groupDefaultRules.map(internal_getAccess);
@@ -193,7 +193,7 @@ export function unstable_getGroupDefaultAccessAll(
   const allRules = internal_getAclRules(aclDataset);
   const defaultRules = internal_getDefaultAclRulesForResource(
     allRules,
-    aclDataset.accessTo
+    aclDataset.internal_accessTo
   );
   return getAccessByGroup(defaultRules);
 }

--- a/src/datatypes.test.ts
+++ b/src/datatypes.test.ts
@@ -164,7 +164,9 @@ describe("isLiteral", () => {
 describe("isLocalNode", () => {
   it("recognises a LocalNode", () => {
     expect(
-      isLocalNode(Object.assign(DataFactory.blankNode(), { name: "localNode" }))
+      isLocalNode(
+        Object.assign(DataFactory.blankNode(), { internal_name: "localNode" })
+      )
     ).toBe(true);
   });
 
@@ -183,7 +185,7 @@ describe("getLocalNode", () => {
   it("constructs a proper LocalNode", () => {
     const localNode = getLocalNode("some-name");
     expect(localNode.termType).toBe("BlankNode");
-    expect(localNode.name).toBe("some-name");
+    expect(localNode.internal_name).toBe("some-name");
   });
 });
 
@@ -210,10 +212,10 @@ describe("asNamedNode", () => {
 describe("isEqual", () => {
   it("recognises two equal LocalNodes without needing a Resource IRI", () => {
     const localNode1: LocalNode = Object.assign(DataFactory.blankNode(), {
-      name: "some-name",
+      internal_name: "some-name",
     });
     const localNode2: LocalNode = Object.assign(DataFactory.blankNode(), {
-      name: "some-name",
+      internal_name: "some-name",
     });
     expect(isEqual(localNode1, localNode2)).toBe(true);
   });
@@ -224,7 +226,7 @@ describe("isEqual", () => {
   });
   it("recognises the equality of a LocalNode with the same resource IRI to a NamedNode", () => {
     const localNode: LocalNode = Object.assign(DataFactory.blankNode(), {
-      name: "some-name",
+      internal_name: "some-name",
     });
     const namedNode = DataFactory.namedNode(
       "https://some.pod/resource#some-name"
@@ -242,7 +244,7 @@ describe("isEqual", () => {
   });
   it("recognises the inequality of a LocalNode with a different resource IRI to a NamedNode", () => {
     const localNode: LocalNode = Object.assign(DataFactory.blankNode(), {
-      name: "some-name",
+      internal_name: "some-name",
     });
     const namedNode = DataFactory.namedNode(
       "https://some.pod/resource#some-name"
@@ -260,7 +262,7 @@ describe("isEqual", () => {
   });
   it("does not mark a LocalNode as equal to a NamedNode if no resource IRI is known", () => {
     const localNode: LocalNode = Object.assign(DataFactory.blankNode(), {
-      name: "some-name",
+      internal_name: "some-name",
     });
     const namedNode = DataFactory.namedNode(
       "https://some.pod/resource#some-name"
@@ -273,10 +275,10 @@ describe("isEqual", () => {
 describe("resolveIriForLocalNodes", () => {
   it("properly resolves the IRI for the Subject and the Object", () => {
     const localNodeSubject: LocalNode = Object.assign(DataFactory.blankNode(), {
-      name: "some-subject",
+      internal_name: "some-subject",
     });
     const localNodeObject: LocalNode = Object.assign(DataFactory.blankNode(), {
-      name: "some-object",
+      internal_name: "some-object",
     });
     const quad = DataFactory.quad(
       localNodeSubject,
@@ -316,7 +318,7 @@ describe("resolveIriForLocalNodes", () => {
 describe("resolveIriForLocalNode", () => {
   it("properly resolves the IRI for a LocalNode", () => {
     const localNode: LocalNode = Object.assign(DataFactory.blankNode(), {
-      name: "some-name",
+      internal_name: "some-name",
     });
     expect(
       resolveIriForLocalNode(localNode, "https://some.pod/resource").value

--- a/src/datatypes.ts
+++ b/src/datatypes.ts
@@ -204,7 +204,7 @@ export function isLocalNode<T>(value: T | LocalNode): value is LocalNode {
     typeof value === "object" &&
     typeof (value as LocalNode).termType === "string" &&
     (value as LocalNode).termType === "BlankNode" &&
-    typeof (value as LocalNode).name === "string"
+    typeof (value as LocalNode).internal_name === "string"
   );
 }
 
@@ -217,7 +217,7 @@ export function isLocalNode<T>(value: T | LocalNode): value is LocalNode {
  */
 export function getLocalNode(name: string): LocalNode {
   const localNode: LocalNode = Object.assign(DataFactory.blankNode(), {
-    name: name,
+    internal_name: name,
   });
   return localNode;
 }
@@ -263,7 +263,7 @@ export function isEqual(
     return node1.equals(node2);
   }
   if (isLocalNode(node1) && isLocalNode(node2)) {
-    return node1.name === node2.name;
+    return node1.internal_name === node2.internal_name;
   }
   if (typeof options.resourceIri === "undefined") {
     // If we don't know what IRI to resolve the LocalNode to,
@@ -310,7 +310,9 @@ export function resolveIriForLocalNode(
   localNode: LocalNode,
   resourceIri: IriString
 ): NamedNode {
-  return DataFactory.namedNode(resolveLocalIri(localNode.name, resourceIri));
+  return DataFactory.namedNode(
+    resolveLocalIri(localNode.internal_name, resourceIri)
+  );
 }
 
 /**

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -144,7 +144,7 @@ describe("End-to-end tests", () => {
     const fallbackAclForDatasetWithoutAcl = unstable_getFallbackAcl(
       datasetWithoutAcl
     );
-    expect(fallbackAclForDatasetWithoutAcl?.accessTo).toBe(
+    expect(fallbackAclForDatasetWithoutAcl?.internal_accessTo).toBe(
       "https://lit-e2e-test.inrupt.net/public/lit-pod-acl-test/"
     );
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -47,15 +47,15 @@ export type LitDataset = DatasetCore;
  * Graph, from a single Resource.
  */
 export type Thing = DatasetCore &
-  ({ url: UrlString } | { localSubject: LocalNode });
+  ({ internal_url: UrlString } | { internal_localSubject: LocalNode });
 /**
  * A [[Thing]] for which we know what the full Subject URL is.
  */
-export type ThingPersisted = Thing & { url: UrlString };
+export type ThingPersisted = Thing & { internal_url: UrlString };
 /**
  * A [[Thing]] whose full Subject URL will be determined when it is persisted.
  */
-export type ThingLocal = Thing & { localSubject: LocalNode };
+export type ThingLocal = Thing & { internal_localSubject: LocalNode };
 /**
  * Represents the BlankNode that will be initialised to a NamedNode when persisted.
  *
@@ -64,7 +64,7 @@ export type ThingLocal = Thing & { localSubject: LocalNode };
  *
  * @internal Utility method; library users should not need to interact with LocalNodes directly.
  */
-export type LocalNode = BlankNode & { name: string };
+export type LocalNode = BlankNode & { internal_name: string };
 
 /**
  * A [[LitDataset]] containing Access Control rules for another LitDataset.
@@ -73,7 +73,7 @@ export type LocalNode = BlankNode & { name: string };
  * function is still experimental and can change in a non-major release.
  */
 export type unstable_AclDataset = LitDataset &
-  WithResourceInfo & { accessTo: UrlString };
+  WithResourceInfo & { internal_accessTo: UrlString };
 
 /**
  * @hidden Developers shouldn't need to directly access ACL rules. Instead, we provide our own functions that verify what access someone has.
@@ -110,7 +110,7 @@ type unstable_WacAllow = {
  * [[LitDataset]]s fetched by lit-pod include this metadata describing its relation to a Pod Resource.
  */
 export type WithResourceInfo = {
-  resourceInfo: {
+  internal_resourceInfo: {
     fetchedFrom: UrlString;
     isLitDataset: boolean;
     contentType?: string;
@@ -138,7 +138,7 @@ export type WithResourceInfo = {
  * @internal Data structure to keep track of operations done by us; should not be read or manipulated by the developer.
  */
 export type WithChangeLog = {
-  changeLog: {
+  internal_changeLog: {
     additions: Quad[];
     deletions: Quad[];
   };
@@ -148,7 +148,7 @@ export type WithChangeLog = {
  * @hidden Developers should use [[unstable_getResourceAcl]] and [[unstable_getFallbackAcl]] to access these.
  */
 export type unstable_WithAcl = {
-  acl: {
+  internal_acl: {
     resourceAcl: unstable_AclDataset | null;
     fallbackAcl: unstable_AclDataset | null;
   };
@@ -160,8 +160,8 @@ export type unstable_WithAcl = {
 export type unstable_WithResourceAcl<
   Resource extends unstable_WithAcl = unstable_WithAcl
 > = Resource & {
-  acl: {
-    resourceAcl: Exclude<unstable_WithAcl["acl"]["resourceAcl"], null>;
+  internal_acl: {
+    resourceAcl: Exclude<unstable_WithAcl["internal_acl"]["resourceAcl"], null>;
   };
 };
 
@@ -171,8 +171,8 @@ export type unstable_WithResourceAcl<
 export type unstable_WithFallbackAcl<
   Resource extends unstable_WithAcl = unstable_WithAcl
 > = Resource & {
-  acl: {
-    fallbackAcl: Exclude<unstable_WithAcl["acl"]["fallbackAcl"], null>;
+  internal_acl: {
+    fallbackAcl: Exclude<unstable_WithAcl["internal_acl"]["fallbackAcl"], null>;
   };
 };
 
@@ -191,7 +191,7 @@ export function hasResourceInfo<T extends LitDataset>(
   dataset: T
 ): dataset is T & WithResourceInfo {
   const potentialResourceInfo = dataset as T & WithResourceInfo;
-  return typeof potentialResourceInfo.resourceInfo === "object";
+  return typeof potentialResourceInfo.internal_resourceInfo === "object";
 }
 
 /** @internal */
@@ -200,9 +200,9 @@ export function hasChangelog<T extends LitDataset>(
 ): dataset is T & WithChangeLog {
   const potentialChangeLog = dataset as T & WithChangeLog;
   return (
-    typeof potentialChangeLog.changeLog === "object" &&
-    Array.isArray(potentialChangeLog.changeLog.additions) &&
-    Array.isArray(potentialChangeLog.changeLog.deletions)
+    typeof potentialChangeLog.internal_changeLog === "object" &&
+    Array.isArray(potentialChangeLog.internal_changeLog.additions) &&
+    Array.isArray(potentialChangeLog.internal_changeLog.deletions)
   );
 }
 
@@ -218,7 +218,7 @@ export function unstable_hasAcl<T extends object>(
   dataset: T
 ): dataset is T & unstable_WithAcl {
   const potentialAcl = dataset as T & unstable_WithAcl;
-  return typeof potentialAcl.acl === "object";
+  return typeof potentialAcl.internal_acl === "object";
 }
 
 /**
@@ -227,9 +227,9 @@ export function unstable_hasAcl<T extends object>(
 export type unstable_WithAccessibleAcl<
   Resource extends WithResourceInfo = WithResourceInfo
 > = Resource & {
-  resourceInfo: {
+  internal_resourceInfo: {
     unstable_aclUrl: Exclude<
-      WithResourceInfo["resourceInfo"]["unstable_aclUrl"],
+      WithResourceInfo["internal_resourceInfo"]["unstable_aclUrl"],
       undefined
     >;
   };
@@ -248,7 +248,7 @@ export type unstable_WithAccessibleAcl<
 export function unstable_hasAccessibleAcl<Resource extends WithResourceInfo>(
   dataset: Resource
 ): dataset is unstable_WithAccessibleAcl<Resource> {
-  return typeof dataset.resourceInfo.unstable_aclUrl === "string";
+  return typeof dataset.internal_resourceInfo.unstable_aclUrl === "string";
 }
 
 /**

--- a/src/resource/__snapshots__/litDataset.test.ts.snap
+++ b/src/resource/__snapshots__/litDataset.test.ts.snap
@@ -2,6 +2,11 @@
 
 exports[`fetchLitDataset returns a LitDataset representing the fetched Turtle 1`] = `
 DatasetCore {
+  "internal_resourceInfo": Object {
+    "contentType": "text/plain;charset=UTF-8",
+    "fetchedFrom": "https://arbitrary.pod/resource",
+    "isLitDataset": false,
+  },
   "quads": Set {
     Object {
       "graph": Object {
@@ -98,11 +103,6 @@ DatasetCore {
         "value": "https://arbitrary.pod/resource#me",
       },
     },
-  },
-  "resourceInfo": Object {
-    "contentType": "text/plain;charset=UTF-8",
-    "fetchedFrom": "https://arbitrary.pod/resource",
-    "isLitDataset": false,
   },
 }
 `;

--- a/src/resource/litDataset.test.ts
+++ b/src/resource/litDataset.test.ts
@@ -114,7 +114,7 @@ describe("fetchLitDataset", () => {
       fetch: mockFetch,
     });
 
-    expect(litDataset.resourceInfo.fetchedFrom).toBe(
+    expect(litDataset.internal_resourceInfo.fetchedFrom).toBe(
       "https://some.pod/resource"
     );
   });
@@ -136,7 +136,7 @@ describe("fetchLitDataset", () => {
       { fetch: mockFetch }
     );
 
-    expect(litDataset.resourceInfo.unstable_aclUrl).toBe(
+    expect(litDataset.internal_resourceInfo.unstable_aclUrl).toBe(
       "https://some.pod/container/aclresource.acl"
     );
   });
@@ -157,7 +157,7 @@ describe("fetchLitDataset", () => {
       { fetch: mockFetch }
     );
 
-    expect(litDataset.resourceInfo.unstable_aclUrl).toBeUndefined();
+    expect(litDataset.internal_resourceInfo.unstable_aclUrl).toBeUndefined();
   });
 
   it("provides the relevant access permissions to the Resource, if available", async () => {
@@ -176,7 +176,7 @@ describe("fetchLitDataset", () => {
       { fetch: mockFetch }
     );
 
-    expect(litDataset.resourceInfo.unstable_permissions).toEqual({
+    expect(litDataset.internal_resourceInfo.unstable_permissions).toEqual({
       user: {
         read: true,
         append: true,
@@ -209,7 +209,7 @@ describe("fetchLitDataset", () => {
       { fetch: mockFetch }
     );
 
-    expect(litDataset.resourceInfo.unstable_permissions).toEqual({
+    expect(litDataset.internal_resourceInfo.unstable_permissions).toEqual({
       user: {
         read: false,
         append: false,
@@ -239,7 +239,9 @@ describe("fetchLitDataset", () => {
       { fetch: mockFetch }
     );
 
-    expect(litDataset.resourceInfo.unstable_permissions).toBeUndefined();
+    expect(
+      litDataset.internal_resourceInfo.unstable_permissions
+    ).toBeUndefined();
   });
 
   it("returns a LitDataset representing the fetched Turtle", async () => {
@@ -326,15 +328,17 @@ describe("fetchLitDatasetWithAcl", () => {
       { fetch: mockFetch }
     );
 
-    expect(fetchedLitDataset.resourceInfo.fetchedFrom).toBe(
+    expect(fetchedLitDataset.internal_resourceInfo.fetchedFrom).toBe(
       "https://some.pod/resource"
     );
-    expect(fetchedLitDataset.acl?.resourceAcl?.resourceInfo.fetchedFrom).toBe(
-      "https://some.pod/resource.acl"
-    );
-    expect(fetchedLitDataset.acl?.fallbackAcl?.resourceInfo.fetchedFrom).toBe(
-      "https://some.pod/.acl"
-    );
+    expect(
+      fetchedLitDataset.internal_acl?.resourceAcl?.internal_resourceInfo
+        .fetchedFrom
+    ).toBe("https://some.pod/resource.acl");
+    expect(
+      fetchedLitDataset.internal_acl?.fallbackAcl?.internal_resourceInfo
+        .fetchedFrom
+    ).toBe("https://some.pod/.acl");
     expect(mockFetch.mock.calls).toHaveLength(4);
     expect(mockFetch.mock.calls[0][0]).toBe("https://some.pod/resource");
     expect(mockFetch.mock.calls[1][0]).toBe("https://some.pod/resource.acl");
@@ -377,8 +381,8 @@ describe("fetchLitDatasetWithAcl", () => {
     );
 
     expect(mockFetch.mock.calls).toHaveLength(1);
-    expect(fetchedLitDataset.acl.resourceAcl).toBeNull();
-    expect(fetchedLitDataset.acl.fallbackAcl).toBeNull();
+    expect(fetchedLitDataset.internal_acl.resourceAcl).toBeNull();
+    expect(fetchedLitDataset.internal_acl.fallbackAcl).toBeNull();
   });
 
   it("returns a meaningful error when the server returns a 403", async () => {
@@ -527,10 +531,10 @@ describe("saveLitDatasetAt", () => {
         .mockReturnValue(Promise.resolve(new Response()));
       const mockDataset = dataset();
       const subjectLocal: LocalNode = Object.assign(DataFactory.blankNode(), {
-        name: "some-subject-name",
+        internal_name: "some-subject-name",
       });
       const objectLocal: LocalNode = Object.assign(DataFactory.blankNode(), {
-        name: "some-object-name",
+        internal_name: "some-object-name",
       });
       mockDataset.add(
         DataFactory.quad(
@@ -556,10 +560,10 @@ describe("saveLitDatasetAt", () => {
         .mockReturnValue(Promise.resolve(new Response()));
       const mockDataset = dataset();
       const subjectLocal: LocalNode = Object.assign(DataFactory.blankNode(), {
-        name: "some-subject-name",
+        internal_name: "some-subject-name",
       });
       const objectLocal: LocalNode = Object.assign(DataFactory.blankNode(), {
-        name: "some-object-name",
+        internal_name: "some-object-name",
       });
       mockDataset.add(
         DataFactory.quad(
@@ -594,7 +598,7 @@ describe("saveLitDatasetAt", () => {
         mockDataset
       );
 
-      expect(storedLitDataset.changeLog).toEqual({
+      expect(storedLitDataset.internal_changeLog).toEqual({
         additions: [],
         deletions: [],
       });
@@ -617,7 +621,7 @@ describe("saveLitDatasetAt", () => {
 
   describe("when updating an existing resource", () => {
     function getMockUpdatedDataset(
-      changeLog: WithChangeLog["changeLog"],
+      changeLog: WithChangeLog["internal_changeLog"],
       fromUrl: IriString
     ): LitDataset & WithChangeLog & WithResourceInfo {
       const mockDataset = dataset();
@@ -634,14 +638,14 @@ describe("saveLitDatasetAt", () => {
         mockDataset.add(tripleToAdd)
       );
 
-      const resourceInfo: WithResourceInfo["resourceInfo"] = {
+      const resourceInfo: WithResourceInfo["internal_resourceInfo"] = {
         fetchedFrom: fromUrl,
         isLitDataset: true,
       };
 
       return Object.assign(mockDataset, {
-        changeLog: changeLog,
-        resourceInfo: resourceInfo,
+        internal_changeLog: changeLog,
+        internal_resourceInfo: resourceInfo,
       });
     }
 
@@ -696,10 +700,10 @@ describe("saveLitDatasetAt", () => {
         .mockReturnValue(Promise.resolve(new Response()));
 
       const subjectLocal: LocalNode = Object.assign(DataFactory.blankNode(), {
-        name: "some-subject-name",
+        internal_name: "some-subject-name",
       });
       const objectLocal: LocalNode = Object.assign(DataFactory.blankNode(), {
-        name: "some-object-name",
+        internal_name: "some-object-name",
       });
       const mockDataset = getMockUpdatedDataset(
         {
@@ -741,10 +745,10 @@ describe("saveLitDatasetAt", () => {
         .mockReturnValue(Promise.resolve(new Response()));
 
       const subjectLocal: LocalNode = Object.assign(DataFactory.blankNode(), {
-        name: "some-subject-name",
+        internal_name: "some-subject-name",
       });
       const objectLocal: LocalNode = Object.assign(DataFactory.blankNode(), {
-        name: "some-object-name",
+        internal_name: "some-object-name",
       });
       const mockDataset = getMockUpdatedDataset(
         {
@@ -888,7 +892,7 @@ describe("saveLitDatasetAt", () => {
         mockDataset
       );
 
-      expect(storedLitDataset.changeLog).toEqual({
+      expect(storedLitDataset.internal_changeLog).toEqual({
         additions: [],
         deletions: [],
       });
@@ -1029,10 +1033,10 @@ describe("saveLitDatasetInContainer", () => {
       .fn(window.fetch)
       .mockReturnValue(Promise.resolve(mockResponse));
     const subjectLocal: LocalNode = Object.assign(DataFactory.blankNode(), {
-      name: "some-subject-name",
+      internal_name: "some-subject-name",
     });
     const objectLocal: LocalNode = Object.assign(DataFactory.blankNode(), {
-      name: "some-object-name",
+      internal_name: "some-object-name",
     });
     const mockDataset = dataset();
     mockDataset.add(
@@ -1112,7 +1116,7 @@ describe("saveLitDatasetInContainer", () => {
       }
     );
 
-    expect(savedLitDataset.resourceInfo.fetchedFrom).toBe(
+    expect(savedLitDataset.internal_resourceInfo.fetchedFrom).toBe(
       "https://some.pod/container/resource"
     );
   });
@@ -1127,10 +1131,10 @@ describe("saveLitDatasetInContainer", () => {
     );
 
     const subjectLocal: LocalNode = Object.assign(DataFactory.blankNode(), {
-      name: "some-subject-name",
+      internal_name: "some-subject-name",
     });
     const objectLocal: LocalNode = Object.assign(DataFactory.blankNode(), {
-      name: "some-object-name",
+      internal_name: "some-object-name",
     });
     const mockDataset = dataset();
     mockDataset.add(
@@ -1175,7 +1179,7 @@ describe("saveLitDatasetInContainer", () => {
       }
     );
 
-    expect(savedLitDataset.resourceInfo.fetchedFrom).toBe(
+    expect(savedLitDataset.internal_resourceInfo.fetchedFrom).toBe(
       "https://some.pod/container/resource"
     );
   });

--- a/src/resource/nonRdfData.test.ts
+++ b/src/resource/nonRdfData.test.ts
@@ -90,9 +90,9 @@ describe("unstable_fetchFile", () => {
       fetch: mockFetch,
     });
 
-    expect(file.resourceInfo.fetchedFrom).toEqual("https://some.url");
-    expect(file.resourceInfo.contentType).toContain("text/plain");
-    expect(file.resourceInfo.isLitDataset).toEqual(false);
+    expect(file.internal_resourceInfo.fetchedFrom).toEqual("https://some.url");
+    expect(file.internal_resourceInfo.contentType).toContain("text/plain");
+    expect(file.internal_resourceInfo.isLitDataset).toEqual(false);
 
     const fileData = await file.text();
     expect(fileData).toEqual("Some data");
@@ -192,9 +192,9 @@ describe("unstable_fetchFileWithAcl", () => {
       fetch: mockFetch,
     });
 
-    expect(file.resourceInfo.fetchedFrom).toEqual("https://some.url");
-    expect(file.resourceInfo.contentType).toContain("text/plain");
-    expect(file.resourceInfo.isLitDataset).toEqual(false);
+    expect(file.internal_resourceInfo.fetchedFrom).toEqual("https://some.url");
+    expect(file.internal_resourceInfo.contentType).toContain("text/plain");
+    expect(file.internal_resourceInfo.isLitDataset).toEqual(false);
 
     const fileData = await file.text();
     expect(fileData).toEqual("Some data");
@@ -220,15 +220,17 @@ describe("unstable_fetchFileWithAcl", () => {
       { fetch: mockFetch }
     );
 
-    expect(fetchedLitDataset.resourceInfo.fetchedFrom).toBe(
+    expect(fetchedLitDataset.internal_resourceInfo.fetchedFrom).toBe(
       "https://some.pod/resource"
     );
-    expect(fetchedLitDataset.acl?.resourceAcl?.resourceInfo.fetchedFrom).toBe(
-      "https://some.pod/resource.acl"
-    );
-    expect(fetchedLitDataset.acl?.fallbackAcl?.resourceInfo.fetchedFrom).toBe(
-      "https://some.pod/.acl"
-    );
+    expect(
+      fetchedLitDataset.internal_acl?.resourceAcl?.internal_resourceInfo
+        .fetchedFrom
+    ).toBe("https://some.pod/resource.acl");
+    expect(
+      fetchedLitDataset.internal_acl?.fallbackAcl?.internal_resourceInfo
+        .fetchedFrom
+    ).toBe("https://some.pod/.acl");
     expect(mockFetch.mock.calls).toHaveLength(4);
     expect(mockFetch.mock.calls[0][0]).toBe("https://some.pod/resource");
     expect(mockFetch.mock.calls[1][0]).toBe("https://some.pod/resource.acl");
@@ -254,8 +256,8 @@ describe("unstable_fetchFileWithAcl", () => {
     );
 
     expect(mockFetch.mock.calls).toHaveLength(1);
-    expect(fetchedLitDataset.acl.resourceAcl).toBeNull();
-    expect(fetchedLitDataset.acl.fallbackAcl).toBeNull();
+    expect(fetchedLitDataset.internal_acl.resourceAcl).toBeNull();
+    expect(fetchedLitDataset.internal_acl.fallbackAcl).toBeNull();
   });
 
   it("returns a meaningful error when the server returns a 403", async () => {

--- a/src/resource/nonRdfData.ts
+++ b/src/resource/nonRdfData.ts
@@ -71,7 +71,7 @@ export async function unstable_fetchFile(
   const resourceInfo = internal_parseResourceInfo(response);
   const data = await response.blob();
   const fileWithResourceInfo: Blob & WithResourceInfo = Object.assign(data, {
-    resourceInfo: resourceInfo,
+    internal_resourceInfo: resourceInfo,
   });
 
   return fileWithResourceInfo;
@@ -83,7 +83,7 @@ export async function unstable_fetchFileWithAcl(
 ): Promise<Blob & WithResourceInfo & unstable_WithAcl> {
   const file = await unstable_fetchFile(input, options);
   const acl = await internal_fetchAcl(file, options);
-  return Object.assign(file, { acl });
+  return Object.assign(file, { internal_acl: acl });
 }
 
 const defaultSaveOptions = {

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -58,7 +58,7 @@ describe("fetchAcl", () => {
     };
 
     const mockResourceInfo: WithResourceInfo = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: true,
         unstable_aclUrl: "https://some.pod/resource.acl",
@@ -77,7 +77,7 @@ describe("fetchAcl", () => {
     const mockFetch = jest.fn(window.fetch);
 
     const mockResourceInfo: WithResourceInfo = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: true,
       },
@@ -109,7 +109,7 @@ describe("fetchAcl", () => {
     });
 
     const mockResourceInfo: WithResourceInfo = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: true,
         unstable_aclUrl: "https://some.pod/resource.acl",
@@ -122,7 +122,7 @@ describe("fetchAcl", () => {
 
     expect(fetchedAcl).not.toBeNull();
     expect(fetchedAcl.fallbackAcl).toBeNull();
-    expect(fetchedAcl.resourceAcl?.resourceInfo.fetchedFrom).toBe(
+    expect(fetchedAcl.resourceAcl?.internal_resourceInfo.fetchedFrom).toBe(
       "https://some.pod/resource.acl"
     );
   });
@@ -153,7 +153,7 @@ describe("fetchAcl", () => {
     });
 
     const mockResourceInfo: WithResourceInfo = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: true,
         unstable_aclUrl: "https://some.pod/resource.acl",
@@ -165,7 +165,7 @@ describe("fetchAcl", () => {
     });
 
     expect(fetchedAcl.resourceAcl).toBeNull();
-    expect(fetchedAcl.fallbackAcl?.resourceInfo.fetchedFrom).toBe(
+    expect(fetchedAcl.fallbackAcl?.internal_resourceInfo.fetchedFrom).toBe(
       "https://some.pod/.acl"
     );
   });
@@ -193,15 +193,17 @@ describe("fetchResourceInfoWithAcl", () => {
       { fetch: mockFetch }
     );
 
-    expect(fetchedLitDataset.resourceInfo.fetchedFrom).toBe(
+    expect(fetchedLitDataset.internal_resourceInfo.fetchedFrom).toBe(
       "https://some.pod/resource"
     );
-    expect(fetchedLitDataset.acl?.resourceAcl?.resourceInfo.fetchedFrom).toBe(
-      "https://some.pod/resource.acl"
-    );
-    expect(fetchedLitDataset.acl?.fallbackAcl?.resourceInfo.fetchedFrom).toBe(
-      "https://some.pod/.acl"
-    );
+    expect(
+      fetchedLitDataset.internal_acl?.resourceAcl?.internal_resourceInfo
+        .fetchedFrom
+    ).toBe("https://some.pod/resource.acl");
+    expect(
+      fetchedLitDataset.internal_acl?.fallbackAcl?.internal_resourceInfo
+        .fetchedFrom
+    ).toBe("https://some.pod/.acl");
     expect(mockFetch.mock.calls).toHaveLength(4);
     expect(mockFetch.mock.calls[0][0]).toBe("https://some.pod/resource");
     expect(mockFetch.mock.calls[1][0]).toBe("https://some.pod/resource.acl");
@@ -249,8 +251,8 @@ describe("fetchResourceInfoWithAcl", () => {
     );
 
     expect(mockFetch.mock.calls).toHaveLength(1);
-    expect(fetchedLitDataset.acl.resourceAcl).toBeNull();
-    expect(fetchedLitDataset.acl.fallbackAcl).toBeNull();
+    expect(fetchedLitDataset.internal_acl.resourceAcl).toBeNull();
+    expect(fetchedLitDataset.internal_acl.fallbackAcl).toBeNull();
   });
 
   it("returns a meaningful error when the server returns a 403", async () => {
@@ -636,7 +638,7 @@ describe("fetchResourceInfo", () => {
 describe("isContainer", () => {
   it("should recognise a Container", () => {
     const resourceInfo: WithResourceInfo = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/container/",
         isLitDataset: true,
       },
@@ -647,7 +649,7 @@ describe("isContainer", () => {
 
   it("should recognise non-Containers", () => {
     const resourceInfo: WithResourceInfo = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/container/not-a-container",
         isLitDataset: true,
       },
@@ -660,7 +662,7 @@ describe("isContainer", () => {
 describe("isLitDataset", () => {
   it("should recognise a LitDataset", () => {
     const resourceInfo: WithResourceInfo = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/container/",
         isLitDataset: true,
       },
@@ -671,7 +673,7 @@ describe("isLitDataset", () => {
 
   it("should recognise non-RDF Resources", () => {
     const resourceInfo: WithResourceInfo = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/container/not-a-litdataset.png",
         isLitDataset: false,
       },
@@ -684,7 +686,7 @@ describe("isLitDataset", () => {
 describe("getContentType", () => {
   it("should return the Content Type if known", () => {
     const resourceInfo: WithResourceInfo = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
         isLitDataset: true,
         contentType: "multipart/form-data; boundary=something",
@@ -698,7 +700,7 @@ describe("getContentType", () => {
 
   it("should return null if no Content Type is known", () => {
     const resourceInfo: WithResourceInfo = {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
         isLitDataset: true,
       },

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -51,7 +51,7 @@ export async function internal_fetchResourceInfo(
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
-): Promise<WithResourceInfo["resourceInfo"]> {
+): Promise<WithResourceInfo["internal_resourceInfo"]> {
   const config = {
     ...internal_defaultFetchOptions,
     ...options,
@@ -82,7 +82,7 @@ export async function internal_fetchAcl(
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
-): Promise<unstable_WithAcl["acl"]> {
+): Promise<unstable_WithAcl["internal_acl"]> {
   if (!unstable_hasAccessibleAcl(resourceInfo)) {
     return {
       resourceAcl: null,
@@ -125,8 +125,14 @@ export async function unstable_fetchResourceInfoWithAcl(
   > = internal_defaultFetchOptions
 ): Promise<WithResourceInfo & unstable_WithAcl> {
   const resourceInfo = await internal_fetchResourceInfo(url, options);
-  const acl = await internal_fetchAcl({ resourceInfo }, options);
-  return Object.assign({ resourceInfo }, { acl });
+  const acl = await internal_fetchAcl(
+    { internal_resourceInfo: resourceInfo },
+    options
+  );
+  return Object.assign(
+    { internal_resourceInfo: resourceInfo },
+    { internal_acl: acl }
+  );
 }
 
 /**
@@ -134,14 +140,14 @@ export async function unstable_fetchResourceInfoWithAcl(
  */
 export function internal_parseResourceInfo(
   response: Response
-): WithResourceInfo["resourceInfo"] {
+): WithResourceInfo["internal_resourceInfo"] {
   const contentTypeParts =
     response.headers.get("Content-Type")?.split(";") ?? [];
   const isLitDataset =
     contentTypeParts.length > 0 &&
     ["text/turtle", "application/ld+json"].includes(contentTypeParts[0]);
 
-  const resourceInfo: WithResourceInfo["resourceInfo"] = {
+  const resourceInfo: WithResourceInfo["internal_resourceInfo"] = {
     fetchedFrom: response.url,
     isLitDataset: isLitDataset,
     contentType: response.headers.get("Content-Type") ?? undefined,
@@ -181,7 +187,7 @@ export function isContainer(resource: WithResourceInfo): boolean {
  * @return Whether `resource` contains a LitDataset.
  */
 export function isLitDataset(resource: WithResourceInfo): boolean {
-  return resource.resourceInfo.isLitDataset;
+  return resource.internal_resourceInfo.isLitDataset;
 }
 
 /**
@@ -189,7 +195,7 @@ export function isLitDataset(resource: WithResourceInfo): boolean {
  * @returns The Content Type, if known, or null if not known.
  */
 export function getContentType(resource: WithResourceInfo): string | null {
-  return resource.resourceInfo.contentType ?? null;
+  return resource.internal_resourceInfo.contentType ?? null;
 }
 
 /**
@@ -197,7 +203,7 @@ export function getContentType(resource: WithResourceInfo): string | null {
  * @returns The URL from which the resource has been fetched
  */
 export function getFetchedFrom(resource: WithResourceInfo): string {
-  return resource.resourceInfo.fetchedFrom;
+  return resource.internal_resourceInfo.fetchedFrom;
 }
 
 /**

--- a/src/thing/add.test.ts
+++ b/src/thing/add.test.ts
@@ -38,7 +38,7 @@ import {
 
 function getMockEmptyThing(iri = "https://arbitrary.vocab/subject") {
   const thing = dataset();
-  return Object.assign(thing, { url: iri });
+  return Object.assign(thing, { internal_url: iri });
 }
 function literalOfType(
   literalType: "string" | "integer" | "decimal" | "boolean" | "dateTime",
@@ -140,11 +140,11 @@ describe("addIri", () => {
     const thing = getMockEmptyThing("https://some.pod/resource#subject");
     const localSubject: LocalNode = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localObject" }
+      { internal_name: "localObject" }
     );
     const datasetWithThingLocal = dataset();
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = addUrl(
@@ -161,7 +161,9 @@ describe("addIri", () => {
         predicate: "https://some.vocab/predicate",
       })
     ).toBe(true);
-    expect((updatedQuads[0].object as LocalNode).name).toBe("localObject");
+    expect((updatedQuads[0].object as LocalNode).internal_name).toBe(
+      "localObject"
+    );
   });
 
   it("accepts Predicates as Named Nodes", () => {
@@ -200,11 +202,11 @@ describe("addIri", () => {
   it("also works on ThingLocals", () => {
     const localSubject: LocalNode = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const datasetWithThingLocal = dataset();
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = addUrl(
@@ -221,7 +223,9 @@ describe("addIri", () => {
         object: DataFactory.namedNode("https://some.pod/other-resource#object"),
       })
     ).toBe(true);
-    expect((updatedQuads[0].subject as LocalNode).name).toBe("localSubject");
+    expect((updatedQuads[0].subject as LocalNode).internal_name).toBe(
+      "localSubject"
+    );
   });
 
   it("preserves existing values for the same Predicate", () => {
@@ -352,11 +356,11 @@ describe("addBoolean", () => {
   it("also works on ThingLocals", () => {
     const localSubject: LocalNode = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const datasetWithThingLocal = dataset();
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = addBoolean(
@@ -373,7 +377,9 @@ describe("addBoolean", () => {
         object: literalOfType("boolean", "1"),
       })
     ).toBe(true);
-    expect((updatedQuads[0].subject as LocalNode).name).toBe("localSubject");
+    expect((updatedQuads[0].subject as LocalNode).internal_name).toBe(
+      "localSubject"
+    );
   });
 
   it("preserves existing values for the same Predicate", () => {
@@ -502,11 +508,11 @@ describe("addDatetime", () => {
   it("also works on ThingLocals", () => {
     const localSubject: LocalNode = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const datasetWithThingLocal = dataset();
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = addDatetime(
@@ -523,7 +529,9 @@ describe("addDatetime", () => {
         object: literalOfType("dateTime", "1990-11-12T13:37:42Z"),
       })
     ).toBe(true);
-    expect((updatedQuads[0].subject as LocalNode).name).toBe("localSubject");
+    expect((updatedQuads[0].subject as LocalNode).internal_name).toBe(
+      "localSubject"
+    );
   });
 
   it("preserves existing values for the same Predicate", () => {
@@ -652,11 +660,11 @@ describe("addDecimal", () => {
   it("also works on ThingLocals", () => {
     const localSubject: LocalNode = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const datasetWithThingLocal = dataset();
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = addDecimal(
@@ -673,7 +681,9 @@ describe("addDecimal", () => {
         object: literalOfType("decimal", "13.37"),
       })
     ).toBe(true);
-    expect((updatedQuads[0].subject as LocalNode).name).toBe("localSubject");
+    expect((updatedQuads[0].subject as LocalNode).internal_name).toBe(
+      "localSubject"
+    );
   });
 
   it("preserves existing values for the same Predicate", () => {
@@ -798,11 +808,11 @@ describe("addInteger", () => {
   it("also works on ThingLocals", () => {
     const localSubject: LocalNode = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const datasetWithThingLocal = dataset();
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = addInteger(
@@ -819,7 +829,9 @@ describe("addInteger", () => {
         object: literalOfType("integer", "42"),
       })
     ).toBe(true);
-    expect((updatedQuads[0].subject as LocalNode).name).toBe("localSubject");
+    expect((updatedQuads[0].subject as LocalNode).internal_name).toBe(
+      "localSubject"
+    );
   });
 
   it("preserves existing values for the same Predicate", () => {
@@ -943,11 +955,11 @@ describe("addStringWithLocale", () => {
   it("also works on ThingLocals", () => {
     const localSubject: LocalNode = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const datasetWithThingLocal = dataset();
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = addStringWithLocale(
@@ -965,7 +977,9 @@ describe("addStringWithLocale", () => {
         object: DataFactory.literal("Some string", "en-gb"),
       })
     ).toBe(true);
-    expect((updatedQuads[0].subject as LocalNode).name).toBe("localSubject");
+    expect((updatedQuads[0].subject as LocalNode).internal_name).toBe(
+      "localSubject"
+    );
   });
 
   it("preserves existing values for the same Predicate", () => {
@@ -1096,11 +1110,11 @@ describe("addStringNoLocale", () => {
   it("also works on ThingLocals", () => {
     const localSubject: LocalNode = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const datasetWithThingLocal = dataset();
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = addStringNoLocale(
@@ -1117,7 +1131,9 @@ describe("addStringNoLocale", () => {
         object: literalOfType("string", "Some string value"),
       })
     ).toBe(true);
-    expect((updatedQuads[0].subject as LocalNode).name).toBe("localSubject");
+    expect((updatedQuads[0].subject as LocalNode).internal_name).toBe(
+      "localSubject"
+    );
   });
 
   it("preserves existing values for the same Predicate", () => {
@@ -1246,11 +1262,11 @@ describe("addNamedNode", () => {
   it("also works on ThingLocals", () => {
     const localSubject: LocalNode = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const datasetWithThingLocal = dataset();
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = addNamedNode(
@@ -1267,7 +1283,9 @@ describe("addNamedNode", () => {
         object: DataFactory.namedNode("https://some.pod/other-resource#object"),
       })
     ).toBe(true);
-    expect((updatedQuads[0].subject as LocalNode).name).toBe("localSubject");
+    expect((updatedQuads[0].subject as LocalNode).internal_name).toBe(
+      "localSubject"
+    );
   });
 
   it("preserves existing values for the same Predicate", () => {
@@ -1399,10 +1417,10 @@ describe("addLiteral", () => {
     const datasetWithThingLocal = dataset();
     const localSubject: LocalNode = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = addLiteral(
@@ -1419,7 +1437,9 @@ describe("addLiteral", () => {
         object: DataFactory.literal("Some string value"),
       })
     ).toBe(true);
-    expect((updatedQuads[0].subject as LocalNode).name).toBe("localSubject");
+    expect((updatedQuads[0].subject as LocalNode).internal_name).toBe(
+      "localSubject"
+    );
   });
 
   it("preserves existing values for the same Predicate", () => {

--- a/src/thing/get.test.ts
+++ b/src/thing/get.test.ts
@@ -69,7 +69,9 @@ function getMockThingWithLiteralFor(
   const thing = dataset();
   thing.add(quad);
 
-  return Object.assign(thing, { url: "https://arbitrary.vocab/subject" });
+  return Object.assign(thing, {
+    internal_url: "https://arbitrary.vocab/subject",
+  });
 }
 function getMockThingWithLiteralsFor(
   predicate: IriString,
@@ -91,7 +93,9 @@ function getMockThingWithLiteralsFor(
   thing.add(quad1);
   thing.add(quad2);
 
-  return Object.assign(thing, { url: "https://arbitrary.vocab/subject" });
+  return Object.assign(thing, {
+    internal_url: "https://arbitrary.vocab/subject",
+  });
 }
 
 describe("getIriOne", () => {
@@ -114,7 +118,9 @@ describe("getIriOne", () => {
     const thing = dataset();
     thing.add(quad);
 
-    return Object.assign(thing, { url: "https://arbitrary.vocab/subject" });
+    return Object.assign(thing, {
+      internal_url: "https://arbitrary.vocab/subject",
+    });
   }
 
   it("returns the IRI value for the given Predicate", () => {
@@ -211,7 +217,9 @@ describe("getIriAll", () => {
     thing.add(quad1);
     thing.add(quad2);
 
-    return Object.assign(thing, { url: "https://arbitrary.vocab/subject" });
+    return Object.assign(thing, {
+      internal_url: "https://arbitrary.vocab/subject",
+    });
   }
 
   it("returns the IRI values for the given Predicate", () => {
@@ -982,7 +990,7 @@ describe("getStringWithLocaleOne", () => {
     const thing = dataset();
     thing.add(quad);
     const thingWithLocaleString = Object.assign(thing, {
-      url: "https://arbitrary.vocab/subject",
+      internal_url: "https://arbitrary.vocab/subject",
     });
 
     expect(
@@ -1004,7 +1012,7 @@ describe("getStringWithLocaleOne", () => {
     const thing = dataset();
     thing.add(quad);
     const thingWithLocaleString = Object.assign(thing, {
-      url: "https://arbitrary.vocab/subject",
+      internal_url: "https://arbitrary.vocab/subject",
     });
 
     expect(
@@ -1026,7 +1034,7 @@ describe("getStringWithLocaleOne", () => {
     const thing = dataset();
     thing.add(quad);
     const thingWithLocaleString = Object.assign(thing, {
-      url: "https://arbitrary.vocab/subject",
+      internal_url: "https://arbitrary.vocab/subject",
     });
 
     expect(
@@ -1064,7 +1072,7 @@ describe("getStringWithLocaleOne", () => {
     const thing = dataset();
     thing.add(quad);
     const thingWithDifferentLocaleString = Object.assign(thing, {
-      url: "https://arbitrary.vocab/subject",
+      internal_url: "https://arbitrary.vocab/subject",
     });
 
     expect(
@@ -1123,7 +1131,7 @@ describe("getStringWithLocaleOne", () => {
     const thing = dataset();
     thing.add(quad);
     const thingWithLocaleString = Object.assign(thing, {
-      url: "https://arbitrary.vocab/subject",
+      internal_url: "https://arbitrary.vocab/subject",
     });
 
     expect(
@@ -1154,7 +1162,7 @@ describe("getStringsWithLocaleAll", () => {
     thing.add(quad1);
     thing.add(quad2);
     const thingWithLocaleStrings = Object.assign(thing, {
-      url: "https://arbitrary.vocab/subject",
+      internal_url: "https://arbitrary.vocab/subject",
     });
 
     expect(
@@ -1183,7 +1191,7 @@ describe("getStringsWithLocaleAll", () => {
     thing.add(quad1);
     thing.add(quad2);
     const thingWithLocaleStrings = Object.assign(thing, {
-      url: "https://arbitrary.vocab/subject",
+      internal_url: "https://arbitrary.vocab/subject",
     });
 
     expect(
@@ -1205,7 +1213,7 @@ describe("getStringsWithLocaleAll", () => {
     const thing = dataset();
     thing.add(quad);
     const thingWithLocaleString = Object.assign(thing, {
-      url: "https://arbitrary.vocab/subject",
+      internal_url: "https://arbitrary.vocab/subject",
     });
 
     expect(
@@ -1243,7 +1251,7 @@ describe("getStringsWithLocaleAll", () => {
     const thing = dataset();
     thing.add(quad);
     const thingWithDifferentLocaleStrings = Object.assign(thing, {
-      url: "https://arbitrary.vocab/subject",
+      internal_url: "https://arbitrary.vocab/subject",
     });
 
     expect(
@@ -1302,7 +1310,7 @@ describe("getStringsWithLocaleAll", () => {
     const thing = dataset();
     thing.add(quad);
     const thingWithLocaleString = Object.assign(thing, {
-      url: "https://arbitrary.vocab/subject",
+      internal_url: "https://arbitrary.vocab/subject",
     });
 
     expect(
@@ -1536,7 +1544,7 @@ describe("getLiteralOne", () => {
     const plainDataset = dataset();
 
     const thingWithoutLiteral: Thing = Object.assign(plainDataset, {
-      url: "https://arbitrary.vocab/subject",
+      internal_url: "https://arbitrary.vocab/subject",
     });
 
     expect(
@@ -1610,7 +1618,7 @@ describe("getLiteralAll", () => {
     const plainDataset = dataset();
 
     const thingWithoutLiterals: Thing = Object.assign(plainDataset, {
-      url: "https://arbitrary.vocab/subject",
+      internal_url: "https://arbitrary.vocab/subject",
     });
 
     expect(
@@ -1662,7 +1670,7 @@ function getMockThingWithNamedNode(
   plainDataset.add(quad);
 
   const thing: Thing = Object.assign(plainDataset, {
-    url: "https://arbitrary.vocab/subject",
+    internal_url: "https://arbitrary.vocab/subject",
   });
   return thing;
 }
@@ -1706,7 +1714,7 @@ describe("getNamedNodeOne", () => {
     const plainDataset = dataset();
 
     const thingWithoutNamedNode: Thing = Object.assign(plainDataset, {
-      url: "https://arbitrary.vocab/subject",
+      internal_url: "https://arbitrary.vocab/subject",
     });
 
     expect(
@@ -1758,7 +1766,7 @@ describe("getNamedNodeAll", () => {
     plainDataset.add(quad2);
 
     const thing: Thing = Object.assign(plainDataset, {
-      url: "https://arbitrary.vocab/subject",
+      internal_url: "https://arbitrary.vocab/subject",
     });
     return thing;
   }
@@ -1803,7 +1811,7 @@ describe("getNamedNodeAll", () => {
     const plainDataset = dataset();
 
     const thingWithoutNamedNodes: Thing = Object.assign(plainDataset, {
-      url: "https://arbitrary.vocab/subject",
+      internal_url: "https://arbitrary.vocab/subject",
     });
 
     expect(

--- a/src/thing/remove.test.ts
+++ b/src/thing/remove.test.ts
@@ -61,7 +61,9 @@ function getMockThingWithLiteralFor(
   const thing = dataset();
   thing.add(quad);
 
-  return Object.assign(thing, { url: "https://arbitrary.vocab/subject" });
+  return Object.assign(thing, {
+    internal_url: "https://arbitrary.vocab/subject",
+  });
 }
 function getMockQuadWithNamedNode(
   predicate: IriString,
@@ -83,7 +85,7 @@ function getMockThingWithNamedNode(
   plainDataset.add(quad);
 
   const thing: Thing = Object.assign(plainDataset, {
-    url: "https://arbitrary.vocab/subject",
+    internal_url: "https://arbitrary.vocab/subject",
   });
   return thing;
 }
@@ -143,7 +145,7 @@ describe("removeAll", () => {
   it("also works on ThingLocals", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const quadWithLocalSubject = DataFactory.quad(
       localSubject,
@@ -153,7 +155,7 @@ describe("removeAll", () => {
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = removeAll(thingLocal, "https://some.vocab/predicate");
@@ -211,7 +213,9 @@ describe("removeIri", () => {
     const thing = dataset();
     thing.add(quad);
 
-    return Object.assign(thing, { url: "https://arbitrary.vocab/subject" });
+    return Object.assign(thing, {
+      internal_url: "https://arbitrary.vocab/subject",
+    });
   }
 
   it("removes the given IRI value for the given Predicate", () => {
@@ -278,7 +282,7 @@ describe("removeIri", () => {
   it("also works on ThingLocals", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const quadWithLocalSubject = DataFactory.quad(
       localSubject,
@@ -288,7 +292,7 @@ describe("removeIri", () => {
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = removeUrl(
@@ -367,7 +371,7 @@ describe("removeIri", () => {
 
   it("resolves ThingPersisteds", () => {
     const thingPersisted: ThingPersisted = Object.assign(dataset(), {
-      url: "https://some.pod/resource#thing",
+      internal_url: "https://some.pod/resource#thing",
     });
     const quadWithThingPersistedIri = DataFactory.quad(
       DataFactory.namedNode("https://arbitrary.vocab/subject"),
@@ -379,7 +383,7 @@ describe("removeIri", () => {
     const thingWithThingPersistedIri: Thing = Object.assign(
       datasetWithThingPersistedIri,
       {
-        url: "https://arbitrary.vocab/subject",
+        internal_url: "https://arbitrary.vocab/subject",
       }
     );
 
@@ -446,7 +450,7 @@ describe("removeBoolean", () => {
   it("also works on ThingLocals", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const quadWithLocalSubject = DataFactory.quad(
       localSubject,
@@ -459,7 +463,7 @@ describe("removeBoolean", () => {
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = removeBoolean(
@@ -596,7 +600,7 @@ describe("removeDatetime", () => {
   it("also works on ThingLocals", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const quadWithLocalSubject = DataFactory.quad(
       localSubject,
@@ -609,7 +613,7 @@ describe("removeDatetime", () => {
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = removeDatetime(
@@ -749,7 +753,7 @@ describe("removeDecimal", () => {
   it("also works on ThingLocals", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const quadWithLocalSubject = DataFactory.quad(
       localSubject,
@@ -762,7 +766,7 @@ describe("removeDecimal", () => {
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = removeDecimal(
@@ -899,7 +903,7 @@ describe("removeInteger", () => {
   it("also works on ThingLocals", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const quadWithLocalSubject = DataFactory.quad(
       localSubject,
@@ -912,7 +916,7 @@ describe("removeInteger", () => {
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = removeInteger(
@@ -1022,7 +1026,9 @@ describe("removeStringWithLocale", () => {
     const thing = dataset();
     thing.add(quad);
 
-    return Object.assign(thing, { url: "https://arbitrary.vocab/subject" });
+    return Object.assign(thing, {
+      internal_url: "https://arbitrary.vocab/subject",
+    });
   }
   it("removes the given localised string for the given Predicate", () => {
     const thingWithStringWithLocale = getMockThingWithStringWithLocaleFor(
@@ -1079,7 +1085,7 @@ describe("removeStringWithLocale", () => {
   it("also works on ThingLocals", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const quadWithLocalSubject = DataFactory.quad(
       localSubject,
@@ -1089,7 +1095,7 @@ describe("removeStringWithLocale", () => {
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = removeStringWithLocale(
@@ -1266,7 +1272,7 @@ describe("removeStringNoLocale", () => {
   it("also works on ThingLocals", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const quadWithLocalSubject = DataFactory.quad(
       localSubject,
@@ -1279,7 +1285,7 @@ describe("removeStringNoLocale", () => {
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = removeStringNoLocale(
@@ -1393,7 +1399,7 @@ describe("removeLiteral", () => {
     thing.add(quad);
 
     const thingWithStringWithLocale = Object.assign(thing, {
-      url: "https://arbitrary.vocab/subject",
+      internal_url: "https://arbitrary.vocab/subject",
     });
 
     const updatedThing = removeLiteral(
@@ -1523,7 +1529,7 @@ describe("removeLiteral", () => {
   it("also works on ThingLocals", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const quadWithLocalSubject = DataFactory.quad(
       localSubject,
@@ -1536,7 +1542,7 @@ describe("removeLiteral", () => {
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = removeLiteral(
@@ -1682,7 +1688,7 @@ describe("removeNamedNode", () => {
   it("also works on ThingLocals", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const quadWithLocalSubject = DataFactory.quad(
       localSubject,
@@ -1692,7 +1698,7 @@ describe("removeNamedNode", () => {
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = removeNamedNode(

--- a/src/thing/set.test.ts
+++ b/src/thing/set.test.ts
@@ -50,7 +50,7 @@ function getMockQuad(
 function getMockThing(quad: Quad) {
   const thing = dataset();
   thing.add(quad);
-  return Object.assign(thing, { url: quad.subject.value });
+  return Object.assign(thing, { internal_url: quad.subject.value });
 }
 function literalOfType(
   literalType: "string" | "integer" | "decimal" | "boolean" | "dateTime",
@@ -148,7 +148,7 @@ describe("setIri", () => {
     );
     const thing = getMockThing(existingQuad);
     const targetThing = Object.assign(dataset(), {
-      url: "https://some.pod/other-resource#object",
+      internal_url: "https://some.pod/other-resource#object",
     });
 
     const updatedThing = setUrl(
@@ -176,10 +176,10 @@ describe("setIri", () => {
     const thing = getMockThing(existingQuad);
     const datasetWithThingLocal = dataset();
     const localSubject: LocalNode = Object.assign(DataFactory.blankNode(), {
-      name: "localObject",
+      internal_name: "localObject",
     });
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = setUrl(
@@ -196,7 +196,9 @@ describe("setIri", () => {
     expect(updatedQuads[0].predicate.value).toBe(
       "https://some.vocab/predicate"
     );
-    expect((updatedQuads[0].object as LocalNode).name).toBe("localObject");
+    expect((updatedQuads[0].object as LocalNode).internal_name).toBe(
+      "localObject"
+    );
   });
 
   it("accepts Predicates as Named Nodes", () => {
@@ -243,10 +245,10 @@ describe("setIri", () => {
   it("also works on ThingLocals", () => {
     const datasetWithThingLocal = dataset();
     const localSubject: LocalNode = Object.assign(DataFactory.blankNode(), {
-      name: "localSubject",
+      internal_name: "localSubject",
     });
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = setUrl(
@@ -257,7 +259,9 @@ describe("setIri", () => {
 
     const updatedQuads = Array.from(updatedThing);
     expect(updatedQuads).toHaveLength(1);
-    expect((updatedQuads[0].subject as LocalNode).name).toBe("localSubject");
+    expect((updatedQuads[0].subject as LocalNode).internal_name).toBe(
+      "localSubject"
+    );
     expect(updatedQuads[0].predicate.value).toBe(
       "https://some.vocab/predicate"
     );
@@ -374,7 +378,7 @@ describe("setBoolean", () => {
   it("also works on ThingLocals", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(
@@ -385,7 +389,7 @@ describe("setBoolean", () => {
       )
     );
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = setBoolean(
@@ -401,7 +405,9 @@ describe("setBoolean", () => {
         object: literalOfType("boolean", "1"),
       })
     ).toBe(true);
-    expect(updatedThing.localSubject.name).toBe("localSubject");
+    expect(updatedThing.internal_localSubject.internal_name).toBe(
+      "localSubject"
+    );
   });
 
   it("preserves existing Quads with different Predicates", () => {
@@ -512,7 +518,7 @@ describe("setDatetime", () => {
   it("also works on ThingLocals", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(
@@ -523,7 +529,7 @@ describe("setDatetime", () => {
       )
     );
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = setDatetime(
@@ -539,7 +545,9 @@ describe("setDatetime", () => {
         object: literalOfType("dateTime", "1990-11-12T13:37:42Z"),
       })
     ).toBe(true);
-    expect(updatedThing.localSubject.name).toBe("localSubject");
+    expect(updatedThing.internal_localSubject.internal_name).toBe(
+      "localSubject"
+    );
   });
 
   it("preserves existing Quads with different Predicates", () => {
@@ -650,7 +658,7 @@ describe("setDecimal", () => {
   it("also works on ThingLocals", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(
@@ -661,7 +669,7 @@ describe("setDecimal", () => {
       )
     );
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = setDecimal(
@@ -677,7 +685,9 @@ describe("setDecimal", () => {
         object: literalOfType("decimal", "13.37"),
       })
     ).toBe(true);
-    expect(updatedThing.localSubject.name).toBe("localSubject");
+    expect(updatedThing.internal_localSubject.internal_name).toBe(
+      "localSubject"
+    );
   });
 
   it("preserves existing Quads with different Predicates", () => {
@@ -784,7 +794,7 @@ describe("setInteger", () => {
   it("also works on ThingLocals", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(
@@ -795,7 +805,7 @@ describe("setInteger", () => {
       )
     );
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = setInteger(
@@ -811,7 +821,9 @@ describe("setInteger", () => {
         object: literalOfType("integer", "42"),
       })
     ).toBe(true);
-    expect(updatedThing.localSubject.name).toBe("localSubject");
+    expect(updatedThing.internal_localSubject.internal_name).toBe(
+      "localSubject"
+    );
   });
 
   it("preserves existing Quads with different Predicates", () => {
@@ -925,7 +937,7 @@ describe("setStringWithLocale", () => {
   it("also works on ThingLocals", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(
@@ -936,7 +948,7 @@ describe("setStringWithLocale", () => {
       )
     );
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = setStringWithLocale(
@@ -953,7 +965,9 @@ describe("setStringWithLocale", () => {
         object: DataFactory.literal("Some string value", "en-gb"),
       })
     ).toBe(true);
-    expect(updatedThing.localSubject.name).toBe("localSubject");
+    expect(updatedThing.internal_localSubject.internal_name).toBe(
+      "localSubject"
+    );
   });
 
   it("preserves existing Quads with different Predicates", () => {
@@ -1065,7 +1079,7 @@ describe("setStringNoLocale", () => {
   it("also works on ThingLocals", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(
@@ -1076,7 +1090,7 @@ describe("setStringNoLocale", () => {
       )
     );
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = setStringNoLocale(
@@ -1092,7 +1106,9 @@ describe("setStringNoLocale", () => {
         object: literalOfType("string", "Some string value"),
       })
     ).toBe(true);
-    expect(updatedThing.localSubject.name).toBe("localSubject");
+    expect(updatedThing.internal_localSubject.internal_name).toBe(
+      "localSubject"
+    );
   });
 
   it("preserves existing Quads with different Predicates", () => {
@@ -1204,10 +1220,10 @@ describe("setNamedNode", () => {
     const datasetWithThingLocal = dataset();
     const localSubject = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = setNamedNode(
@@ -1218,7 +1234,9 @@ describe("setNamedNode", () => {
 
     const updatedQuads = Array.from(updatedThing);
     expect(updatedQuads).toHaveLength(1);
-    expect((updatedQuads[0].subject as LocalNode).name).toBe("localSubject");
+    expect((updatedQuads[0].subject as LocalNode).internal_name).toBe(
+      "localSubject"
+    );
     expect(updatedQuads[0].predicate.value).toBe(
       "https://some.vocab/predicate"
     );
@@ -1334,7 +1352,7 @@ describe("setLiteral", () => {
   it("also works on ThingLocals", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(
@@ -1345,7 +1363,7 @@ describe("setLiteral", () => {
       )
     );
     const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
 
     const updatedThing = setLiteral(
@@ -1361,7 +1379,9 @@ describe("setLiteral", () => {
         object: DataFactory.literal("Some string value"),
       })
     ).toBe(true);
-    expect(updatedThing.localSubject.name).toBe("localSubject");
+    expect(updatedThing.internal_localSubject.internal_name).toBe(
+      "localSubject"
+    );
   });
 
   it("preserves existing Quads with different Predicates", () => {

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -73,15 +73,19 @@ describe("createThing", () => {
     const thing1: ThingLocal = createThing();
     const thing2: ThingLocal = createThing();
 
-    expect(typeof thing1.localSubject.name).toBe("string");
-    expect(thing1.localSubject.name.length).toBeGreaterThan(0);
-    expect(thing1.localSubject.name).not.toEqual(thing2.localSubject.name);
+    expect(typeof thing1.internal_localSubject.internal_name).toBe("string");
+    expect(thing1.internal_localSubject.internal_name.length).toBeGreaterThan(
+      0
+    );
+    expect(thing1.internal_localSubject.internal_name).not.toEqual(
+      thing2.internal_localSubject.internal_name
+    );
   });
 
   it("uses the given name, if any", () => {
     const thing: ThingLocal = createThing({ name: "some-name" });
 
-    expect(thing.localSubject.name).toBe("some-name");
+    expect(thing.internal_localSubject.internal_name).toBe("some-name");
   });
 
   it("uses the given IRI, if any", () => {
@@ -89,7 +93,7 @@ describe("createThing", () => {
       url: "https://some.pod/resource#thing",
     });
 
-    expect(thing.url).toBe("https://some.pod/resource#thing");
+    expect(thing.internal_url).toBe("https://some.pod/resource#thing");
   });
 
   it("throws an error if the given URL is invalid", () => {
@@ -131,7 +135,7 @@ describe("getThingOne", () => {
     const quadWithLocalSubject = getMockQuad();
     const localSubject = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     quadWithLocalSubject.subject = localSubject;
     const datasetWithThingLocal = dataset();
@@ -366,7 +370,7 @@ describe("getThingAll", () => {
     const quadWithLocalSubject = getMockQuad();
     const localSubject = Object.assign(
       DataFactory.blankNode("Blank node representing a LocalNode"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     quadWithLocalSubject.subject = localSubject;
     const datasetWithMultipleThings = dataset();
@@ -400,7 +404,7 @@ describe("setThing", () => {
       object: "https://some.vocab/new-object",
     });
     const newThing: Thing = Object.assign(dataset(), {
-      url: "https://some.vocab/subject",
+      internal_url: "https://some.vocab/subject",
     });
     newThing.add(newThingQuad);
 
@@ -426,14 +430,14 @@ describe("setThing", () => {
       object: "https://some.vocab/new-object",
     });
     const newThing: Thing = Object.assign(dataset(), {
-      url: "https://some.vocab/subject",
+      internal_url: "https://some.vocab/subject",
     });
     newThing.add(newThingQuad);
 
     const updatedDataset = setThing(datasetWithMultipleThings, newThing);
 
-    expect(updatedDataset.changeLog.additions).toEqual([newThingQuad]);
-    expect(updatedDataset.changeLog.deletions).toEqual([oldThingQuad]);
+    expect(updatedDataset.internal_changeLog.additions).toEqual([newThingQuad]);
+    expect(updatedDataset.internal_changeLog.deletions).toEqual([oldThingQuad]);
   });
 
   it("reconciles deletions and additions in the change log", () => {
@@ -459,7 +463,7 @@ describe("setThing", () => {
     const datasetWithExistingChangeLog = Object.assign(
       datasetWithMultipleThings,
       {
-        changeLog: {
+        internal_changeLog: {
           additions: [addedQuad],
           deletions: [deletedQuad],
         },
@@ -471,15 +475,15 @@ describe("setThing", () => {
       object: "https://some.vocab/new-object",
     });
     const newThing: Thing = Object.assign(dataset(), {
-      url: "https://some.vocab/subject",
+      internal_url: "https://some.vocab/subject",
     });
     newThing.add(newThingQuad);
     newThing.add(deletedQuad);
 
     const updatedDataset = setThing(datasetWithExistingChangeLog, newThing);
 
-    expect(updatedDataset.changeLog.additions).toEqual([newThingQuad]);
-    expect(updatedDataset.changeLog.deletions).toEqual([oldThingQuad]);
+    expect(updatedDataset.internal_changeLog.additions).toEqual([newThingQuad]);
+    expect(updatedDataset.internal_changeLog.deletions).toEqual([oldThingQuad]);
   });
 
   it("preserves existing change logs", () => {
@@ -498,7 +502,7 @@ describe("setThing", () => {
     });
     const datasetWithExistingChangeLog: LitDataset &
       WithChangeLog = Object.assign(dataset(), {
-      changeLog: {
+      internal_changeLog: {
         additions: [existingAddition],
         deletions: [existingDeletion],
       },
@@ -511,17 +515,17 @@ describe("setThing", () => {
       object: "https://some.vocab/new-object",
     });
     const newThing: Thing = Object.assign(dataset(), {
-      url: "https://some.vocab/subject",
+      internal_url: "https://some.vocab/subject",
     });
     newThing.add(newThingQuad);
 
     const updatedDataset = setThing(datasetWithExistingChangeLog, newThing);
 
-    expect(updatedDataset.changeLog.additions).toEqual([
+    expect(updatedDataset.internal_changeLog.additions).toEqual([
       existingAddition,
       newThingQuad,
     ]);
-    expect(updatedDataset.changeLog.deletions).toEqual([
+    expect(updatedDataset.internal_changeLog.deletions).toEqual([
       existingDeletion,
       oldThingQuad,
     ]);
@@ -543,7 +547,7 @@ describe("setThing", () => {
     });
     const datasetWithExistingChangeLog: LitDataset &
       WithChangeLog = Object.assign(dataset(), {
-      changeLog: {
+      internal_changeLog: {
         additions: [existingAddition],
         deletions: [existingDeletion],
       },
@@ -556,7 +560,7 @@ describe("setThing", () => {
       object: "https://some.vocab/new-object",
     });
     const newThing: Thing = Object.assign(dataset(), {
-      url: "https://some.vocab/subject",
+      internal_url: "https://some.vocab/subject",
     });
     newThing.add(newThingQuad);
 
@@ -566,10 +570,10 @@ describe("setThing", () => {
       oldThingQuad,
       otherQuad,
     ]);
-    expect(datasetWithExistingChangeLog.changeLog.additions).toEqual([
+    expect(datasetWithExistingChangeLog.internal_changeLog.additions).toEqual([
       existingAddition,
     ]);
-    expect(datasetWithExistingChangeLog.changeLog.deletions).toEqual([
+    expect(datasetWithExistingChangeLog.internal_changeLog.deletions).toEqual([
       existingDeletion,
     ]);
   });
@@ -584,7 +588,7 @@ describe("setThing", () => {
     datasetWithUnexpectedQuad.add(unexpectedQuad);
 
     const thing: Thing = Object.assign(dataset(), {
-      url: "https://arbitrary.vocab/subject",
+      internal_url: "https://arbitrary.vocab/subject",
     });
 
     const updatedDataset = setThing(datasetWithUnexpectedQuad, thing);
@@ -595,7 +599,7 @@ describe("setThing", () => {
   it("can recognise LocalNodes", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Blank node representing a LocalNode"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const mockPredicate = DataFactory.namedNode(
       "https://arbitrary.vocab/predicate"
@@ -614,7 +618,7 @@ describe("setThing", () => {
       DataFactory.namedNode("https://some.vocab/new-object")
     );
     const newThing: Thing = Object.assign(dataset(), {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
     newThing.add(newThingQuad);
 
@@ -631,7 +635,7 @@ describe("setThing", () => {
     const datasetWithNamedNode: LitDataset & WithResourceInfo = Object.assign(
       dataset(),
       {
-        resourceInfo: {
+        internal_resourceInfo: {
           fetchedFrom: "https://some.pod/resource",
           isLitDataset: true,
         },
@@ -641,7 +645,7 @@ describe("setThing", () => {
 
     const localSubject = Object.assign(
       DataFactory.blankNode("Blank node representing a LocalNode"),
-      { name: "subject" }
+      { internal_name: "subject" }
     );
     const mockPredicate = DataFactory.namedNode(
       "https://arbitrary.vocab/predicate"
@@ -652,7 +656,7 @@ describe("setThing", () => {
       DataFactory.namedNode("https://some.vocab/new-object")
     );
     const newThing: Thing = Object.assign(dataset(), {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
     newThing.add(newThingQuad);
 
@@ -664,7 +668,7 @@ describe("setThing", () => {
   it("can reconcile new NamedNodes with existing LocalNodes if the LitDataset has a resource IRI attached", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Blank node representing a LocalNode"),
-      { name: "subject" }
+      { internal_name: "subject" }
     );
     const mockPredicate = DataFactory.namedNode(
       "https://arbitrary.vocab/predicate"
@@ -676,7 +680,7 @@ describe("setThing", () => {
     );
     const datasetWithLocalSubject: LitDataset &
       WithResourceInfo = Object.assign(dataset(), {
-      resourceInfo: {
+      internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: true,
       },
@@ -688,7 +692,7 @@ describe("setThing", () => {
       object: "https://some.vocab/old-object",
     });
     const newThing: Thing = Object.assign(dataset(), {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
     newThing.add(newThingQuad);
 
@@ -700,7 +704,7 @@ describe("setThing", () => {
   it("only updates LocalNodes if the LitDataset has no known IRI", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Blank node representing a LocalNode"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const mockPredicate = DataFactory.namedNode(
       "https://arbitrary.vocab/predicate"
@@ -723,7 +727,7 @@ describe("setThing", () => {
       DataFactory.namedNode("https://some.vocab/new-object")
     );
     const newThing: Thing = Object.assign(dataset(), {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
     newThing.add(newThingQuad);
 
@@ -755,7 +759,7 @@ describe("removeThing", () => {
     datasetWithMultipleThings.add(otherQuad);
 
     const thing: Thing = Object.assign(dataset(), {
-      url: "https://some.vocab/subject",
+      internal_url: "https://some.vocab/subject",
     });
     thing.add(thingQuad);
 
@@ -782,16 +786,18 @@ describe("removeThing", () => {
     datasetWithMultipleThings.add(otherQuad);
 
     const thing: Thing = Object.assign(dataset(), {
-      url: "https://some.vocab/subject",
+      internal_url: "https://some.vocab/subject",
     });
     thing.add(thingQuad);
 
     const updatedDataset = removeThing(datasetWithMultipleThings, thing);
 
-    expect(updatedDataset.changeLog.additions).toEqual([]);
-    expect(updatedDataset.changeLog.deletions).toHaveLength(2);
-    expect(updatedDataset.changeLog.deletions).toContain(sameSubjectQuad);
-    expect(updatedDataset.changeLog.deletions).toContain(thingQuad);
+    expect(updatedDataset.internal_changeLog.additions).toEqual([]);
+    expect(updatedDataset.internal_changeLog.deletions).toHaveLength(2);
+    expect(updatedDataset.internal_changeLog.deletions).toContain(
+      sameSubjectQuad
+    );
+    expect(updatedDataset.internal_changeLog.deletions).toContain(thingQuad);
   });
 
   it("reconciles deletions in the change log with additions", () => {
@@ -811,22 +817,24 @@ describe("removeThing", () => {
     datasetWithMultipleThings.add(sameSubjectQuad);
     datasetWithMultipleThings.add(otherQuad);
     const datasetWithChangelog = Object.assign(datasetWithMultipleThings, {
-      changeLog: {
+      internal_changeLog: {
         additions: [thingQuad],
         deletions: [],
       },
     });
 
     const thing: Thing = Object.assign(dataset(), {
-      url: "https://some.vocab/subject",
+      internal_url: "https://some.vocab/subject",
     });
     thing.add(thingQuad);
 
     const updatedDataset = removeThing(datasetWithChangelog, thing);
 
-    expect(updatedDataset.changeLog.additions).toEqual([]);
-    expect(updatedDataset.changeLog.deletions).toHaveLength(1);
-    expect(updatedDataset.changeLog.deletions).toContain(sameSubjectQuad);
+    expect(updatedDataset.internal_changeLog.additions).toEqual([]);
+    expect(updatedDataset.internal_changeLog.deletions).toHaveLength(1);
+    expect(updatedDataset.internal_changeLog.deletions).toContain(
+      sameSubjectQuad
+    );
   });
 
   it("preserves existing change logs", () => {
@@ -842,7 +850,7 @@ describe("removeThing", () => {
     });
     const datasetWithExistingChangeLog: LitDataset &
       WithChangeLog = Object.assign(dataset(), {
-      changeLog: {
+      internal_changeLog: {
         additions: [existingAddition],
         deletions: [existingDeletion],
       },
@@ -850,14 +858,16 @@ describe("removeThing", () => {
     datasetWithExistingChangeLog.add(thingQuad);
 
     const thing: Thing = Object.assign(dataset(), {
-      url: "https://some.vocab/subject",
+      internal_url: "https://some.vocab/subject",
     });
     thing.add(thingQuad);
 
     const updatedDataset = removeThing(datasetWithExistingChangeLog, thing);
 
-    expect(updatedDataset.changeLog.additions).toEqual([existingAddition]);
-    expect(updatedDataset.changeLog.deletions).toEqual([
+    expect(updatedDataset.internal_changeLog.additions).toEqual([
+      existingAddition,
+    ]);
+    expect(updatedDataset.internal_changeLog.deletions).toEqual([
       existingDeletion,
       thingQuad,
     ]);
@@ -871,7 +881,7 @@ describe("removeThing", () => {
     const datasetWithFetchedAcls: LitDataset & unstable_WithAcl = Object.assign(
       dataset(),
       {
-        acl: {
+        internal_acl: {
           resourceAcl: null,
           fallbackAcl: null,
         },
@@ -880,13 +890,13 @@ describe("removeThing", () => {
     datasetWithFetchedAcls.add(thingQuad);
 
     const thing: Thing = Object.assign(dataset(), {
-      url: "https://some.vocab/subject",
+      internal_url: "https://some.vocab/subject",
     });
     thing.add(thingQuad);
 
     const updatedDataset = removeThing(datasetWithFetchedAcls, thing);
 
-    expect(updatedDataset.acl).toEqual({
+    expect(updatedDataset.internal_acl).toEqual({
       resourceAcl: null,
       fallbackAcl: null,
     });
@@ -898,8 +908,8 @@ describe("removeThing", () => {
       object: "https://some.vocab/new-object",
     });
     const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
-      accessTo: "https://arbitrary.pod/resource",
-      resourceInfo: {
+      internal_accessTo: "https://arbitrary.pod/resource",
+      internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
       },
@@ -907,14 +917,16 @@ describe("removeThing", () => {
     aclDataset.add(thingQuad);
 
     const thing: Thing = Object.assign(dataset(), {
-      url: "https://some.vocab/subject",
+      internal_url: "https://some.vocab/subject",
     });
     thing.add(thingQuad);
 
     const updatedDataset = removeThing(aclDataset, thing);
 
-    expect(updatedDataset.accessTo).toBe("https://arbitrary.pod/resource");
-    expect(updatedDataset.resourceInfo).toEqual({
+    expect(updatedDataset.internal_accessTo).toBe(
+      "https://arbitrary.pod/resource"
+    );
+    expect(updatedDataset.internal_resourceInfo).toEqual({
       fetchedFrom: "https://arbitrary.pod/resource.acl",
       isLitDataset: true,
     });
@@ -938,7 +950,7 @@ describe("removeThing", () => {
     );
 
     expect(Array.from(updatedDataset)).toEqual([otherQuad]);
-    expect(updatedDataset.changeLog.deletions).toEqual([thingQuad]);
+    expect(updatedDataset.internal_changeLog.deletions).toEqual([thingQuad]);
   });
 
   it("does not modify the original LitDataset", () => {
@@ -960,7 +972,8 @@ describe("removeThing", () => {
       otherQuad,
     ]);
     expect(
-      (datasetWithMultipleThings as LitDataset & WithChangeLog).changeLog
+      (datasetWithMultipleThings as LitDataset & WithChangeLog)
+        .internal_changeLog
     ).toBeUndefined();
   });
 
@@ -974,7 +987,7 @@ describe("removeThing", () => {
     datasetWithUnexpectedQuad.add(unexpectedQuad);
 
     const thing: Thing = Object.assign(dataset(), {
-      url: "https://arbitrary.vocab/subject",
+      internal_url: "https://arbitrary.vocab/subject",
     });
 
     const updatedDataset = removeThing(datasetWithUnexpectedQuad, thing);
@@ -1000,13 +1013,13 @@ describe("removeThing", () => {
     );
 
     expect(Array.from(updatedDataset)).toEqual([otherQuad]);
-    expect(updatedDataset.changeLog.deletions).toEqual([thingQuad]);
+    expect(updatedDataset.internal_changeLog.deletions).toEqual([thingQuad]);
   });
 
   it("can recognise LocalNodes", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Blank node representing a LocalNode"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const mockPredicate = DataFactory.namedNode(
       "https://arbitrary.vocab/predicate"
@@ -1022,7 +1035,7 @@ describe("removeThing", () => {
     const updatedDataset = removeThing(datasetWithMultipleThings, localSubject);
 
     expect(Array.from(updatedDataset)).toEqual([]);
-    expect(updatedDataset.changeLog.deletions).toEqual([thingQuad]);
+    expect(updatedDataset.internal_changeLog.deletions).toEqual([thingQuad]);
   });
 
   it("can reconcile given LocalNodes with existing NamedNodes if the LitDataset has a resource IRI attached", () => {
@@ -1033,7 +1046,7 @@ describe("removeThing", () => {
     const datasetWithNamedNode: LitDataset & WithResourceInfo = Object.assign(
       dataset(),
       {
-        resourceInfo: {
+        internal_resourceInfo: {
           fetchedFrom: "https://some.pod/resource",
           isLitDataset: true,
         },
@@ -1043,7 +1056,7 @@ describe("removeThing", () => {
 
     const localSubject = Object.assign(
       DataFactory.blankNode("Blank node representing a LocalNode"),
-      { name: "subject" }
+      { internal_name: "subject" }
     );
 
     const updatedDataset = removeThing(datasetWithNamedNode, localSubject);
@@ -1054,7 +1067,7 @@ describe("removeThing", () => {
   it("can reconcile given NamedNodes with existing LocalNodes if the LitDataset has a resource IRI attached", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Blank node representing a LocalNode"),
-      { name: "subject" }
+      { internal_name: "subject" }
     );
     const mockPredicate = DataFactory.namedNode(
       "https://arbitrary.vocab/predicate"
@@ -1067,7 +1080,7 @@ describe("removeThing", () => {
     const datasetWithLocalNode: LitDataset & WithResourceInfo = Object.assign(
       dataset(),
       {
-        resourceInfo: {
+        internal_resourceInfo: {
           fetchedFrom: "https://some.pod/resource",
           isLitDataset: true,
         },
@@ -1086,7 +1099,7 @@ describe("removeThing", () => {
   it("only removes LocalNodes if the LitDataset has no known IRI", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Blank node representing a LocalNode"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const mockPredicate = DataFactory.namedNode(
       "https://arbitrary.vocab/predicate"
@@ -1106,14 +1119,14 @@ describe("removeThing", () => {
     const updatedDataset = removeThing(datasetWithMultipleThings, localSubject);
 
     expect(Array.from(updatedDataset)).toEqual([similarSubjectQuad]);
-    expect(updatedDataset.changeLog.deletions).toEqual([thingQuad]);
+    expect(updatedDataset.internal_changeLog.deletions).toEqual([thingQuad]);
   });
 });
 
 describe("asIri", () => {
   it("returns the IRI of a persisted Thing", () => {
     const persistedThing: Thing = Object.assign(dataset(), {
-      url: "https://some.pod/resource#thing",
+      internal_url: "https://some.pod/resource#thing",
     });
 
     expect(asUrl(persistedThing)).toBe("https://some.pod/resource#thing");
@@ -1121,9 +1134,11 @@ describe("asIri", () => {
 
   it("returns the IRI of a local Thing relative to a given base IRI", () => {
     const localSubject: LocalNode = Object.assign(DataFactory.blankNode(), {
-      name: "some-name",
+      internal_name: "some-name",
     });
-    const localThing = Object.assign(dataset(), { localSubject: localSubject });
+    const localThing = Object.assign(dataset(), {
+      internal_localSubject: localSubject,
+    });
 
     expect(asUrl(localThing, "https://some.pod/resource")).toBe(
       "https://some.pod/resource#some-name"
@@ -1132,9 +1147,11 @@ describe("asIri", () => {
 
   it("throws an error when a local Thing was given without a base IRI", () => {
     const localSubject: LocalNode = Object.assign(DataFactory.blankNode(), {
-      name: "some-name",
+      internal_name: "some-name",
     });
-    const localThing = Object.assign(dataset(), { localSubject: localSubject });
+    const localThing = Object.assign(dataset(), {
+      internal_localSubject: localSubject,
+    });
 
     expect(() => asUrl(localThing, undefined as any)).toThrow(
       "The URL of a Thing that has not been persisted cannot be determined without a base URL."
@@ -1146,10 +1163,10 @@ describe("toNode", () => {
   it("should result in equal LocalNodes for the same ThingLocal", () => {
     const localSubject: LocalNode = Object.assign(
       DataFactory.blankNode("Arbitrary blank node"),
-      { name: "localSubject" }
+      { internal_name: "localSubject" }
     );
     const thing: ThingLocal = Object.assign(dataset(), {
-      localSubject: localSubject,
+      internal_localSubject: localSubject,
     });
     const node1 = toNode(thing);
     const node2 = toNode(thing);

--- a/website/docs/faq.mdx
+++ b/website/docs/faq.mdx
@@ -1,0 +1,17 @@
+---
+id: faq
+title: Frequently Asked Questions
+sidebar_label: Frequently Asked Questions
+---
+
+### What are these properties/functions with an `internal_` prefix?
+
+There is some metadata and functionality that lit-pod exposes or attaches to the data structures it
+returns, that are for internal use and/or allows your editor to warn you when you are passing the
+wrong type of data to its functions. These are _not_ intended for direct access, and they might
+change without warning in newer versions.
+
+For each of these pieces of data, lit-pod exposes non-internal functions such as
+[`getContentType`](./api/modules/_resource_resource_.md#getcontenttype) to access them and that
+_are_ part of the officially supported API, and hence can be relied upon not to break without
+warning.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -46,7 +46,7 @@ module.exports = {
     {
       type: "category",
       label: "Other",
-      items: ["glossary"],
+      items: ["glossary", "faq"],
     },
   ],
 };


### PR DESCRIPTION
We attach some properties to LitDataset and Thing that we do not
intend for the developer to access directly, because we will likely
be moving that data into the Dataset itself in the future. Instead,
we provide functions to access that data.

To more explicitly discourage direct access to those properties,
they are now tagged as internal as well.

For review, the most important change is in `interfaces.ts`. The rest is just applying the resulting renames and fixing mock data in tests.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
